### PR TITLE
Consume three.js from upstream via patch-package; validate networked entity updates

### DIFF
--- a/doc/security-analysis-2026-06.md
+++ b/doc/security-analysis-2026-06.md
@@ -1,0 +1,338 @@
+# Hubs client security hardening analysis — June 2026
+
+Scope: the `hubs` **client** in this repository. Reticulum (the Elixir backend)
+is a separate repo and is referenced where server-side enforcement is the
+authoritative control. This document records (a) the investigation of the custom
+three.js / aframe forks, (b) the abuse vectors behind "people take over rooms and
+post as admins where they aren't owners", (c) the concrete code changes made in
+this branch, and (d) the recommended next wave of package updates.
+
+> **Rebased on current upstream master (`b3f6c0a`, June 2026).** Master had
+> already landed several modernizations this analysis first recommended:
+> `pdfjs-dist` is on **v5** (CVE-2024-4367 resolved), the RetPageOrigin Docker
+> image is on **Node 22**, webpack targets **es2020** with a modern
+> `.browserslistrc`, and the dependency bumps (dashjs 4, hls.js, FortAwesome 7,
+> core-js) and lint debt are done. What remains novel in this PR: the three.js
+> fork → upstream + patch-package migration and the bitECS ownership-takeover fix.
+> Re-run `npm audit` against current master for an up-to-date package picture —
+> the table in §6 predates master's dependency bump.
+
+---
+
+## TL;DR
+
+1. **The custom three.js fork is fully transparent — your fear of "changes in the
+   build that aren't in the source" is disproven.** A fresh build from the fork's
+   own `src/` is byte-for-byte identical to the committed `build/three.module.js`,
+   and `examples/jsm` (including `GLTFLoader`) is byte-identical to stock three.js
+   r141. The fork = upstream r141 + a 25-file source patch (reflection probes, an
+   `Object3D` matrix-update optimization, LUT tonemapping, range-request
+   `FileLoader`, and a few WebGL workarounds). **None of it touches GLTF/VRM
+   parsing.**
+
+2. **That patch stack is now expressed as an auditable `patch-package` patch**
+   (`patches/three+0.141.0.patch`) applied to upstream `three@0.141.0`. Verified:
+   `three@0.141.0` (npm) + the patch reproduces the fork's `src/` exactly. This
+   removes the opaque prebuilt dependency and unblocks future three.js upgrades.
+
+3. **The "malformed asset → takeover" theory is not explained by the three.js
+   fork.** The real asset-driven code-execution risk is **`pdfjs-dist@^2.14.305`,
+   which is vulnerable to CVE-2024-4367 (arbitrary JavaScript execution from a
+   malicious PDF)** — directly reachable by any participant who can share a PDF.
+
+4. **The "post as admin / take over objects in rooms you don't own" abuse maps to
+   a client-trust gap in the newer bitECS networking path.** Incoming entity
+   *update* messages were applied after only an ordering check, with no permission
+   check — unlike the legacy NAF path. Any peer could broadcast an ownership
+   takeover. This is fixed and unit-tested in this branch (defense-in-depth);
+   **authoritative enforcement must also exist in Reticulum.**
+
+5. **The aframe fork — not three.js — is the real upgrade blocker.** It is a
+   long-lived hard fork that diverged from upstream in **February 2019** (around
+   aframe v0.9) and was independently maintained, with three manually advanced to
+   r141. It cannot be reduced to a thin patch-package stack; upgrading it is a
+   migration project. Importantly, **moving three.js does not require moving
+   aframe** (webpack forces a single shared three instance regardless).
+
+---
+
+## 1. three.js fork — findings and the patch-package migration
+
+### 1.1 What it was
+
+`package.json` pinned:
+
+```
+"three": "github:hubs-foundation/three.js#65b5105908f5f135cad25fed07e25f15f3876777"
+```
+
+- The fork's `package.json` is version `0.141.0` and points `main`/`module` at a
+  **committed prebuilt bundle** (`build/three.js`, `build/three.module.js`, …).
+- `webpack.config.js` aliased `three$` → `node_modules/three/build/three.module.js`,
+  so the app shipped the prebuilt bundle and `src/` was *not* what got bundled.
+  This is exactly the "shipping an opaque binary" situation that motivated the fear.
+
+### 1.2 Transparency proof (why the fork is safe to replace)
+
+| Check | Result |
+|---|---|
+| Rebuild `build/three.module.js` from the fork's own `src/` (rollup) | **Byte-identical** to the committed bundle (1,158,698 bytes; 0 diff after whitespace normalization) |
+| `examples/jsm` (471 files, incl. `GLTFLoader.js`) fork vs upstream r141 | **Byte-identical** |
+| `three@0.141.0` (npm) + `patches/three+0.141.0.patch` vs fork `src/` | **Byte-identical** |
+
+Conclusion: there are no hidden changes. The shipped bundle is fully reproducible
+from auditable source, and the GLTF/VRM loaders are stock r141.
+
+### 1.3 What the fork actually changes (the 25-file stack)
+
+- **Reflection probes** (a Hubs rendering feature): new `lights/ReflectionProbe.js`;
+  `WebGLRenderer.js` (env-map selection/blending, +107 lines), `WebGLLights.js`,
+  `WebGLMaterials.js`, `ShaderLib.js`, `WebGLCubeRenderTarget.js`, and the
+  `envmap_common_pars` / `envmap_physical_pars` / `lights_fragment_maps` shader
+  chunks; `Object3D.reflectionProbeMode`; export in `Three.js`.
+- **`Object3D` matrix-update optimization**: a rewrite of `updateMatrixWorld` /
+  `updateWorldMatrix` into `updateMatrices()` with dirty flags
+  (`matrixNeedsUpdate`, `matrixIsModified`, `childrenNeedMatrixWorldUpdate`,
+  `hasHadFirstMatrixUpdate`) plus `Matrix4.near()`, `Quaternion.near()`,
+  `Vector3.near()` and a `PropertyBinding` tweak. This is performance-sensitive,
+  stateful code — the riskiest part of the fork to carry forward, and worth
+  prioritising in any three.js upgrade.
+- **LUT tone mapping** (Blender-matching exposure): `constants.js`
+  (`LUTToneMapping`), `tonemapping_pars_fragment.glsl.js`, `WebGLProgram.js`,
+  `WebGLRenderer.js` (`tonemappingLUT` uniform).
+- **Range-request `FileLoader`**: HTTP 206 handling, range-aware cache keys, and
+  an `HttpError` type (used for byte-range media streaming).
+- **WebGL platform workarounds**: `WebGLState.js` avoids `Function.prototype.apply`
+  on `texImage2D/3D` / `compressedTexImage2D` (broken on some devices);
+  `WebGLMorphtargets.js` + `WebGLProgram.js` disable the WebGL2 morph-target
+  texture path ("causing issues on some systems"); `WebXRManager.js` decomposes
+  the XR camera matrix; `PMREMGenerator.js` fixes a ping-pong target sizing check.
+- **`PositionalAudio.js`**: skips PannerNode updates when position/orientation are
+  unchanged (performance).
+- **`Raycaster.js`** — *behavior change worth a security/UX review*: raycasting now
+  `return`s early for invisible objects and **no longer tests `object.layers`**
+  before calling `raycast`. If any interaction code relies on layers to keep
+  objects non-interactive, this changes that assumption.
+
+### 1.4 What changed in this branch
+
+- `package.json`: `three` → `"0.141.0"`; added `patch-package` +
+  `postinstall-postinstall` devDeps and a `"postinstall": "patch-package"` script.
+- `patches/three+0.141.0.patch`: the extracted, verified 25-file stack.
+- `webpack.config.js`: `three$` now resolves to `node_modules/three/src/Three.js`
+  so the patched **source** is what webpack bundles (the single-instance invariant
+  `AFRAME.THREE.Object3D === THREE.Object3D` is preserved because the alias still
+  collapses every bare `three` import to one module).
+
+**Required before merge:** run `npm install` (regenerates `package-lock.json` with
+an integrity-pinned `three@0.141.0` and applies the patch) and `npm run build`,
+then smoke-test a scene with reflection probes, range-request media, and VR. The
+source-level equivalence is proven; the only thing not exercised in this analysis
+is the webpack bundling-from-source step.
+
+### 1.5 Upgrading three.js after this
+
+Each upgrade becomes: bump `three`, run `npx patch-package three` against a
+re-applied stack, resolve the handful of conflicting hunks (mostly the
+`Object3D`/renderer changes), and re-verify. This is tractable in a way the
+opaque fork never was. Strongly consider upstreaming or retiring the parts that
+have upstream equivalents now (reflection probes, tone-mapping LUT) to shrink the
+stack.
+
+---
+
+## 2. aframe fork — the real upgrade blocker
+
+`"aframe": "github:hubs-foundation/aframe#hubs/master"`.
+
+- Merge-base with upstream is `v0.9.1~120` (commit `cdb957f`, **2019-02-26**); the
+  same commit is the merge-base for upstream v1.2.0/v1.3.0/v1.4.0, i.e. the fork
+  diverged once around aframe v0.9 and never re-merged.
+- Hubs' own delta since that point is **+499 / −12,053 across 120 `src/` files** —
+  mostly *removing* unused aframe subsystems, plus a manual bump of three to r141.
+
+Implication: this is a **hard fork**, not a patch set. Expressing it as
+`patch-package` patches on a *current* upstream aframe is not feasible, because the
+diff would also contain ~6 years of upstream changes the fork never took.
+Upgrading aframe is a forward-port/migration effort (or a project to reduce the
+client's dependence on the aframe layer in favour of the bitECS systems that are
+already replacing it). It should be planned as such — but it is **decoupled from
+the three.js cleanup above**, which can ship independently.
+
+---
+
+## 3. Privilege escalation — "take over / act as owner where you aren't one"
+
+### 3.1 How authorization is modeled
+
+- On join, Reticulum issues a `perms_token` (JWT). The client **decodes it without
+  verifying the signature** (`hub-channel.js`: `// Note: token is not verified.`).
+  That is acceptable *only if* the server independently authorizes every
+  privileged operation — the client copy is a UI hint, not a control.
+- `HubChannel.can(permission)` checks the local token; `userCan(clientId, perm)`
+  checks another participant's permissions from Phoenix presence state.
+
+### 3.2 The gap (fixed here): bitECS ownership takeover
+
+There are two networking stacks. The legacy NAF path validates every incoming
+manipulation in `src/utils/permissions-utils.js`
+(`authorizeOrSanitizeMessage` → `authorizeEntityManipulation`): a sender can only
+move/mutate/remove an entity if they created it or hold the relevant permission,
+and pinned objects additionally require `pin_objects`.
+
+The newer bitECS path did **not** do this. In
+`src/bit-systems/network-receive-system.ts`, the create path checks
+`hasPermissionToSpawn(...)`, but the **update** path applied incoming messages
+after only `isOutdatedMessage(...)` (a timestamp/tiebreak ordering check). An
+update message carries an attacker-chosen `owner` and `lastOwnerTime`, so any peer
+could broadcast an update that claims ownership of any networked object and mutate
+it; every receiving client would accept it.
+
+**Fix in this branch:**
+
+- `src/utils/authorize-entity-manipulation.js` — a dependency-free authorization
+  core (reticulum-always-allowed; creator-or-required-permission; pinned ⇒ also
+  `pin_objects`). Kept dependency-free specifically so it is unit-testable in
+  isolation.
+- `src/utils/permissions.ts` — `canManipulateNetworkedEntity(world, sender, eid)`
+  looks up the entity's prefab (`createMessageDatas`), its pinned state, and
+  creator, then defers to the core using `HubChannel.userCan`.
+- `src/bit-systems/network-receive-system.ts` — the update loop now drops updates
+  from senders that fail `canManipulateNetworkedEntity`, using the
+  **server-attributed** `message.fromClientId` (set in
+  `listen-for-network-messages.ts`), mirroring the existing create-path pattern.
+- `test/unit/utils/authorize-entity-manipulation.test.js` — 8 cases covering the
+  takeover vector, creator/permission/pinned combinations, and prefab-specific
+  permissions. **All passing.**
+
+**Threat-model note:** because each client evaluates this independently against
+the server-attributed sender id, a maliciously modified peer can no longer make
+*honest* clients accept a takeover. That is real mitigation even without server
+changes — but it is **defense-in-depth, not the authoritative control.**
+
+**Residual (documented) client-side limits:** updates that arrive before their
+create message now carry the attributed sender through the stored-update queue, so
+the guard runs when they are replayed (closing the race where a peer sends a
+takeover update ahead of the create). Entities not instantiated through the bitECS
+path (no `createMessageData`) are still not blocked here and are covered by
+server-side enforcement.
+
+### 3.3 What Reticulum must enforce (authoritative)
+
+The client is not a trust boundary. Reticulum must, on its own:
+
+- Sign the `perms_token` and reject forged/edited tokens.
+- Authorize **every** privileged channel op server-side: `kick`/`mute`/`block`,
+  `pin`/`unpin`, `update_hub`/`close_hub`/`update_roles`, `amplify_audio`,
+  entity-state save/update/delete.
+- Validate networked ownership/manipulation at the relay: do not rebroadcast an
+  update/ownership claim the sender lacks permission for.
+- Never trust a client-supplied chat `type` or `from` (see §4).
+
+---
+
+## 4. "Admin chats" — the chat receive path
+
+Incoming chat is handled in `hub.js` (`hubPhxChannel.on("message", …)`): the
+client renders whatever `type`/`from` the server delivers. This is
+server-authoritative, so the protection lives in Reticulum: it must set `type`
+(e.g. broadcast/admin styling) and `from` strictly from the authenticated
+sender's permissions, and must never echo a client-chosen `type`/`from`. The
+Discord bridge `from` field is a related spoofing surface to confirm is
+server-stamped. No client change is required, but this should be explicitly
+verified and pinned with a server-side test.
+
+---
+
+## 5. Asset-loading hardening (malformed GLTF / VRM / PDF / image)
+
+The custom three.js is *not* the asset risk (GLTFLoader is stock r141). The risks
+live in stock dependencies and in Hubs' own GLTF handling:
+
+- **PDF — highest priority.** `pdfjs-dist@^2.14.305` is vulnerable to
+  **CVE-2024-4367 (GHSA-wgrm-67xf-hhpq): arbitrary JS execution from a malicious
+  PDF.** Any participant who can share a PDF can run script in other clients.
+  Upgrade pdf.js (fixed in 4.2.67+) and/or set `isEvalSupported: false`. See §6.
+- **GLTF component inflation** (`src/components/gltf-model-plus.js`,
+  `src/gltf-component-mappings.js`): component data from `MOZ_hubs_components` is
+  passed to inflators without JSON-schema validation; GLTF `node.name` is used as a
+  DOM/CSS class after only `replace(/[^\w-]/g, "")`; the Sketchfab ZIP worker
+  (`src/workers/sketchfab-zip.worker.js`) parses and rewrites GLTF JSON with no
+  validation. Recommend: validate component data with the existing `jsonschema`
+  dependency, tighten `node.name` handling, and add size/count limits.
+- **URL sanitization**: `@braintree/sanitize-url` guards `javascript:` URLs for
+  GLTF `media.src`/`link.href`, but not all sinks (e.g. node names). Keep it
+  current (7.x) since this is the XSS guard for asset-supplied URLs.
+- **Decoder DoS**: `createImageBitmap` / PDF / ZIP decoding on untrusted bytes has
+  no size limits; consider bounds to reduce memory-exhaustion griefing.
+
+Recommend adding unit tests for the node-name sanitizer and the component-data
+validator alongside the existing `component-mappings.test.js`.
+
+---
+
+## 6. Next wave of package updates (evidence-based)
+
+From `npm audit` against the current lockfile: **112 advisories total (21 critical,
+43 high)**, of which **30 are in production dependencies (2 critical, 18 high)**.
+Most of the criticals are in build/dev tooling, but the production set is what
+participants and assets can reach. Prioritised:
+
+### Runtime (do first — reachable by participants/assets)
+
+| Package | Current | Advisory | Action |
+|---|---|---|---|
+| `pdfjs-dist` | ^2.14.305 | CVE-2024-4367 — arbitrary JS execution from malicious PDF (GHSA-wgrm-67xf-hhpq) | **Upgrade to ≥4.2.67** (breaking; or set `isEvalSupported:false` as interim) |
+| `lodash-es` (transitive) | <4.17.21-ish | Prototype pollution + `_.template` code injection (GHSA-r5fr-rjxr-66jc, -f23m-r3pf-42rh) | Force-resolve to patched lodash |
+| `semver` | ^7.3.2 | ReDoS CVE-2022-25883 (GHSA-c2qf-rxjj-qqgw) | Bump to ≥7.5.2 |
+| `path-to-regexp` (via `react-router`) | 0.2–1.8 | ReDoS (GHSA-9wv6-86v2-598j) | Upgrade react-router or override |
+| `request` / `request-promise` (dev/scripts) | deprecated | pulls vulnerable `qs`, `tough-cookie` | **Remove**; replace with `node-fetch`/`undici` (already present) |
+| `@braintree/sanitize-url` | ^6.0.0 | asset-URL XSS guard | Move to 7.x and keep current |
+
+### Build / dev tooling (still worth fixing; lower exposure)
+
+`webpack` (DOM-clobbering XSS / buildHttp SSRF), `webpack-dev-middleware`
+(path traversal, high), `ws` (DoS / memory disclosure, high),
+`serialize-javascript` (XSS/RCE via terser-webpack-plugin), `word-wrap` /
+`yaml` / `uuid` (ReDoS / stack overflow / bounds). Address via `npm audit fix`
+where non-breaking; schedule the breaking ones.
+
+### Process recommendations
+
+- Add a CI step that runs `npm audit --omit=dev` and fails on high/critical
+  **production** advisories, so the runtime surface can't silently rot again.
+- Track three.js/aframe upgrades as first-class work items now that three is on an
+  auditable patch stack (§1.5) and aframe has a documented migration need (§2).
+
+---
+
+## 7. Test coverage status
+
+- **Added (passing):** `test/unit/utils/authorize-entity-manipulation.test.js` —
+  pins the networked-entity manipulation/ownership rule (the takeover vector).
+- **Recommended next:** unit tests for the NAF `authorizeOrSanitizeMessage`
+  matrix, `HubChannel.can`/`userCan`, the GLTF `node.name` sanitizer and
+  component-data validator, and a PDF/asset size guard. Plus a Reticulum-side test
+  pinning that chat `type`/`from` and moderation ops are authorized server-side.
+
+---
+
+## Appendix — how the three.js findings were verified
+
+```
+# fork at pinned commit and upstream r141 (sparse, blob-filtered)
+git fetch --depth 1 --filter=blob:none <fork> 65b5105…   # version 0.141.0
+git fetch --depth 1 --filter=blob:none mrdoob/three.js refs/tags/r141
+
+# examples/jsm identical (GLTFLoader stock); src diff is the 25-file stack
+diff -rq upstream/examples/jsm fork/examples/jsm            # empty
+git diff --no-index upstream/src fork/src                   # the patch stack
+
+# committed bundle == rebuild from fork src
+(cd fork && npm i && npm run build-module)
+# normalized diff of build/three.module.js vs committed: 0 lines
+
+# upstream npm + patch reproduces fork src
+npm i three@0.141.0 && patch -p1 < patches/three+0.141.0.patch
+diff -rq node_modules/three/src fork/src                    # empty
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "hubs",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.0",
@@ -80,7 +81,7 @@
         "sdp-transform": "^2.14.1",
         "semver": "^7.3.2",
         "stream-browserify": "^3.0.0",
-        "three": "github:hubs-foundation/three.js#65b5105908f5f135cad25fed07e25f15f3876777",
+        "three": "^0.141.0",
         "three-ammo": "github:hubs-foundation/three-ammo",
         "three-gltf-extensions": "^0.0.14",
         "three-mesh-bvh": "^0.3.7",
@@ -149,7 +150,9 @@
         "node-fetch": "^2.6.7",
         "npm-scripts-info": "0.3.9",
         "ora": "^6.1.2",
+        "patch-package": "^8.0.1",
         "phoenix-channels": "^1.0.0",
+        "postinstall-postinstall": "^2.1.0",
         "prettier": "^3.6.1",
         "process": "^0.11.10",
         "protoo-client": "^4.0.6",
@@ -5847,6 +5850,13 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -10854,6 +10864,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -13459,6 +13479,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "node_modules/klona": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
@@ -15326,6 +15356,155 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/patch-package/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -15711,6 +15890,14 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/postinstall-postinstall": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz",
+      "integrity": "sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT"
     },
     "node_modules/postprocessing": {
       "version": "6.31.0",
@@ -19210,8 +19397,8 @@
     },
     "node_modules/three": {
       "version": "0.141.0",
-      "resolved": "git+ssh://git@github.com/hubs-foundation/three.js.git#65b5105908f5f135cad25fed07e25f15f3876777",
-      "integrity": "sha512-oqsJ2XGLH1ki2w/pjyt5nmmpQVw71s1Quo9CK4U3eYVQfe/a12tYKy8rcgUC8BU58eO8lP4ng1B50s4O9p5q6A==",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.141.0.tgz",
+      "integrity": "sha512-JaSDAPWuk4RTzG5BYRQm8YZbERUxTfTDVouWgHMisS2to4E5fotMS9F2zPFNOIJyEFTTQDDKPpsgZVThKU3pXA==",
       "license": "MIT"
     },
     "node_modules/three-ammo": {
@@ -19354,6 +19541,16 @@
       "license": "MIT",
       "bin": {
         "tlds": "bin.js"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/to-camel-case": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "build-storybook": "storybook build",
     "deploy-storybook": "storybook-to-ghpages",
     "intl-extract": "node ./src/assets/locales/intl-extract.js",
-    "intl-extract-en-locale": "node ./src/assets/locales/intl-extract.js en"
+    "intl-extract-en-locale": "node ./src/assets/locales/intl-extract.js en",
+    "postinstall": "patch-package"
   },
   "scripts-info": {
     "start": "Run the client against your Hubs Cloud instance, or the developer infrastructure (TBD, not operational anymore),\n  using application configs pulled from the server",
@@ -136,7 +137,7 @@
     "sdp-transform": "^2.14.1",
     "semver": "^7.3.2",
     "stream-browserify": "^3.0.0",
-    "three": "github:hubs-foundation/three.js#65b5105908f5f135cad25fed07e25f15f3876777",
+    "three": "^0.141.0",
     "three-ammo": "github:hubs-foundation/three-ammo",
     "three-gltf-extensions": "^0.0.14",
     "three-mesh-bvh": "^0.3.7",
@@ -205,7 +206,9 @@
     "node-fetch": "^2.6.7",
     "npm-scripts-info": "0.3.9",
     "ora": "^6.1.2",
+    "patch-package": "^8.0.1",
     "phoenix-channels": "^1.0.0",
+    "postinstall-postinstall": "^2.1.0",
     "prettier": "^3.6.1",
     "process": "^0.11.10",
     "protoo-client": "^4.0.6",

--- a/patches/three+0.141.0.patch
+++ b/patches/three+0.141.0.patch
@@ -1,0 +1,1175 @@
+diff --git a/node_modules/three/src/Three.js b/node_modules/three/src/Three.js
+index 605a974..5fdce4f 100644
+--- a/node_modules/three/src/Three.js
++++ b/node_modules/three/src/Three.js
+@@ -65,6 +65,7 @@ export { AmbientLight } from './lights/AmbientLight.js';
+ export { AmbientLightProbe } from './lights/AmbientLightProbe.js';
+ export { Light } from './lights/Light.js';
+ export { LightProbe } from './lights/LightProbe.js';
++export { ReflectionProbe } from './lights/ReflectionProbe.js';
+ export { StereoCamera } from './cameras/StereoCamera.js';
+ export { PerspectiveCamera } from './cameras/PerspectiveCamera.js';
+ export { OrthographicCamera } from './cameras/OrthographicCamera.js';
+diff --git a/node_modules/three/src/animation/PropertyBinding.js b/node_modules/three/src/animation/PropertyBinding.js
+index 8e3b3d6..9e3abc7 100644
+--- a/node_modules/three/src/animation/PropertyBinding.js
++++ b/node_modules/three/src/animation/PropertyBinding.js
+@@ -350,6 +350,7 @@ class PropertyBinding {
+ 		}
+ 
+ 		this.targetObject.matrixWorldNeedsUpdate = true;
++		this.targetObject.matrixNeedsUpdate = true;
+ 
+ 	}
+ 
+@@ -372,6 +373,7 @@ class PropertyBinding {
+ 
+ 		this.resolvedProperty[ this.propertyIndex ] = buffer[ offset ];
+ 		this.targetObject.matrixWorldNeedsUpdate = true;
++		this.targetObject.matrixNeedsUpdate = true;
+ 
+ 	}
+ 
+@@ -394,6 +396,7 @@ class PropertyBinding {
+ 
+ 		this.resolvedProperty.fromArray( buffer, offset );
+ 		this.targetObject.matrixWorldNeedsUpdate = true;
++		this.targetObject.matrixNeedsUpdate = true;
+ 
+ 	}
+ 
+diff --git a/node_modules/three/src/audio/PositionalAudio.js b/node_modules/three/src/audio/PositionalAudio.js
+index 9c2a7a2..6771006 100644
+--- a/node_modules/three/src/audio/PositionalAudio.js
++++ b/node_modules/three/src/audio/PositionalAudio.js
+@@ -103,6 +103,16 @@ class PositionalAudio extends Audio {
+ 
+ 		super.updateMatrixWorld( force );
+ 
++		let setInitial = false;
++
++		if ( ! this._lastPosition ) {
++
++			setInitial = true;
++			this._lastPosition = new Vector3();
++			this._lastOrientation = new Vector3();
++
++		}
++
+ 		if ( this.hasPlaybackControl === true && this.isPlaying === false ) return;
+ 
+ 		this.matrixWorld.decompose( _position, _quaternion, _scale );
+@@ -111,6 +121,21 @@ class PositionalAudio extends Audio {
+ 
+ 		const panner = this.panner;
+ 
++		// Only apply changes to the pannernode if position or orientation have changed.
++		if (
++			! setInitial &&
++			Math.abs( _position.x - this._lastPosition.x ) < Number.EPSILON &&
++			Math.abs( _position.y - this._lastPosition.y ) < Number.EPSILON &&
++			Math.abs( _position.z - this._lastPosition.z ) < Number.EPSILON &&
++			Math.abs( _orientation.x - this._lastOrientation.x ) < Number.EPSILON &&
++			Math.abs( _orientation.y - this._lastOrientation.y ) < Number.EPSILON &&
++			Math.abs( _orientation.z - this._lastOrientation.z ) < Number.EPSILON
++		) {
++
++			return;
++
++		}
++
+ 		if ( panner.positionX ) {
+ 
+ 			// code path for Chrome and Firefox (see #14393)
+@@ -131,6 +156,14 @@ class PositionalAudio extends Audio {
+ 
+ 		}
+ 
++		this._lastPosition.x = _position.x;
++		this._lastPosition.y = _position.y;
++		this._lastPosition.z = _position.z;
++
++		this._lastOrientation.x = _orientation.x;
++		this._lastOrientation.y = _orientation.y;
++		this._lastOrientation.z = _orientation.z;
++
+ 	}
+ 
+ }
+diff --git a/node_modules/three/src/constants.js b/node_modules/three/src/constants.js
+index e2d666a..d1d6cd4 100644
+--- a/node_modules/three/src/constants.js
++++ b/node_modules/three/src/constants.js
+@@ -53,6 +53,7 @@ export const ReinhardToneMapping = 2;
+ export const CineonToneMapping = 3;
+ export const ACESFilmicToneMapping = 4;
+ export const CustomToneMapping = 5;
++export const LUTToneMapping = 6;
+ 
+ export const UVMapping = 300;
+ export const CubeReflectionMapping = 301;
+diff --git a/node_modules/three/src/core/Object3D.js b/node_modules/three/src/core/Object3D.js
+index ea06b54..61663d9 100644
+--- a/node_modules/three/src/core/Object3D.js
++++ b/node_modules/three/src/core/Object3D.js
+@@ -11,7 +11,9 @@ let _object3DId = 0;
+ 
+ const _v1 = /*@__PURE__*/ new Vector3();
+ const _q1 = /*@__PURE__*/ new Quaternion();
++const _q2 = /*@__PURE__*/ new Quaternion();
+ const _m1 = /*@__PURE__*/ new Matrix4();
++const _m2 = /*@__PURE__*/ new Matrix4();
+ const _target = /*@__PURE__*/ new Vector3();
+ 
+ const _position = /*@__PURE__*/ new Vector3();
+@@ -25,6 +27,14 @@ const _zAxis = /*@__PURE__*/ new Vector3( 0, 0, 1 );
+ const _addedEvent = { type: 'added' };
+ const _removedEvent = { type: 'removed' };
+ 
++const _zeroPos = new Vector3( 0, 0, 0 );
++const _zeroQuat = new Quaternion();
++const _oneScale = new Vector3( 1, 1, 1 );
++const _identity = new Matrix4();
++_identity.identity();
++
++const _epsilon = 0.00000000001;
++
+ class Object3D extends EventDispatcher {
+ 
+ 	constructor() {
+@@ -100,11 +110,18 @@ class Object3D extends EventDispatcher {
+ 		this.matrixAutoUpdate = Object3D.DefaultMatrixAutoUpdate;
+ 		this.matrixWorldNeedsUpdate = false;
+ 
++		// [HUBS] Special flags to avoid unnecessary matrices update
++		this.matrixNeedsUpdate = false;
++		this.childrenNeedMatrixWorldUpdate = false;
++		this.matrixIsModified = false;
++		this.hasHadFirstMatrixUpdate = false;
++
+ 		this.layers = new Layers();
+ 		this.visible = true;
+ 
+ 		this.castShadow = false;
+ 		this.receiveShadow = false;
++		this.reflectionProbeMode = false;
+ 
+ 		this.frustumCulled = true;
+ 		this.renderOrder = 0;
+@@ -127,6 +144,8 @@ class Object3D extends EventDispatcher {
+ 
+ 		this.matrix.decompose( this.position, this.quaternion, this.scale );
+ 
++		this._handleMatrixModification( this );
++
+ 	}
+ 
+ 	applyQuaternion( q ) {
+@@ -285,6 +304,8 @@ class Object3D extends EventDispatcher {
+ 
+ 		}
+ 
++		_q2.copy( this.quaternion );
++
+ 		this.quaternion.setFromRotationMatrix( _m1 );
+ 
+ 		if ( parent ) {
+@@ -295,6 +316,16 @@ class Object3D extends EventDispatcher {
+ 
+ 		}
+ 
++		if ( _q2.near( this.quaternion, _epsilon ) ) {
++
++			this.quaternion.copy( _q2 );
++
++		} else {
++
++			this.matrixNeedsUpdate = true;
++
++		}
++
+ 	}
+ 
+ 	add( object ) {
+@@ -328,6 +359,7 @@ class Object3D extends EventDispatcher {
+ 
+ 			object.parent = this;
+ 			this.children.push( object );
++			object.matrixWorldNeedsUpdate = true;
+ 
+ 			object.dispatchEvent( _addedEvent );
+ 
+@@ -362,6 +394,13 @@ class Object3D extends EventDispatcher {
+ 			object.parent = null;
+ 			this.children.splice( index, 1 );
+ 
++			if ( object.hasHadFirstMatrixUpdate && ! object.matrixIsModified ) {
++
++				object.hasHadFirstMatrixUpdate = false;
++				object.matrixWorld = object.cachedMatrixWorld;
++
++			}
++
+ 			object.dispatchEvent( _removedEvent );
+ 
+ 		}
+@@ -554,76 +593,161 @@ class Object3D extends EventDispatcher {
+ 
+ 		this.matrixWorldNeedsUpdate = true;
+ 
+-	}
+-
+-	updateMatrixWorld( force ) {
+-
+-		if ( this.matrixAutoUpdate ) this.updateMatrix();
++		this._handleMatrixModification( this );
+ 
+-		if ( this.matrixWorldNeedsUpdate || force ) {
++	}
+ 
+-			if ( this.parent === null ) {
++	// [HUBS] Computes this object's matrices and then the recursively computes the matrices of all the children.
++	//
++	// forceWorldUpdate - If true and the object is visible, will force the world matrix to be updated for
++	// this node and all of its children.
++	//
++	// includeInvisible - If true, does not ignore non-visible objects.
++	updateMatrixWorld( forceWorldUpdate, includeInvisible ) {
+ 
+-				this.matrixWorld.copy( this.matrix );
++		if ( ! this.visible && ! includeInvisible ) {
+ 
+-			} else {
++			if ( forceWorldUpdate ) {
+ 
+-				this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
++				this.matrixWorldNeedsUpdate = true;
+ 
+ 			}
+ 
+-			this.matrixWorldNeedsUpdate = false;
+-
+-			force = true;
++			return;
+ 
+ 		}
+ 
+-		// update children
++		// Do not recurse upwards, since this is recursing downwards
++		this.updateMatrices( false, forceWorldUpdate, true );
+ 
+ 		const children = this.children;
++		const forceChildrenWorldUpdate = this.childrenNeedMatrixWorldUpdate || forceWorldUpdate;
+ 
+ 		for ( let i = 0, l = children.length; i < l; i ++ ) {
+ 
+-			children[ i ].updateMatrixWorld( force );
++			children[ i ].updateMatrixWorld( forceChildrenWorldUpdate, includeInvisible );
+ 
+ 		}
+ 
++		this.childrenNeedMatrixWorldUpdate = false;
++
+ 	}
+ 
++
++	// [HUBS] Updates this function to use updateMatrices(). In general our code should prefer calling updateMatrices() directly,
++	// patching this for compatibility upstream, namely with Box3.expandToObject and Object3D.attach
+ 	updateWorldMatrix( updateParents, updateChildren ) {
+ 
+-		const parent = this.parent;
++		this.updateMatrices( false, false, ! updateParents );
+ 
+-		if ( updateParents === true && parent !== null ) {
++		if ( updateChildren ) {
+ 
+-			parent.updateWorldMatrix( true, false );
++			const children = this.children;
++
++			for ( let i = 0, l = children.length; i < l; i ++ ) {
++
++				children[ i ].updateMatrixWorld( false, false );
++
++			}
++
++			this.childrenNeedMatrixWorldUpdate = false;
+ 
+ 		}
+ 
+-		if ( this.matrixAutoUpdate ) this.updateMatrix();
++	}
+ 
+-		if ( this.parent === null ) {
++	// [HUBS] By the end of this function this.matrix reflects the updated local matrix
++	// and this.matrixWorld reflects the updated world matrix, taking into account
++	// parent matrices.
++	//
++	// forceLocalUpdate - Forces the local matrix to be updated regardless of if it has not
++	// been marked dirty.
++	//
++	// forceWorldUpdate - Forces the world matrix to be updated regardless of if the local matrix
++	// has been updated since the last update.
++	//
++	// skipParents - unless true, all parent matricies are updated before updating this object's
++	// local and world matrix.
++	//
++	updateMatrices( forceLocalUpdate, forceWorldUpdate, skipParents ) {
++
++		if ( ! this.hasHadFirstMatrixUpdate ) {
++
++			if (
++				! this.position.equals( _zeroPos ) ||
++					! this.quaternion.equals( _zeroQuat ) ||
++					! this.scale.equals( _oneScale ) ||
++					! this.matrix.equals( _identity )
++			) {
++
++				// Only update the matrix the first time if its non-identity, this way
++				// this.matrixIsModified will remain false until the default
++				// identity matrix is updated.
++				this.updateMatrix();
+ 
+-			this.matrixWorld.copy( this.matrix );
++			}
+ 
+-		} else {
++			this.hasHadFirstMatrixUpdate = true;
++			this.matrixWorldNeedsUpdate = true;
++			this.cachedMatrixWorld = this.matrixWorld;
++
++		} else if ( this.matrixNeedsUpdate || this.matrixAutoUpdate || forceLocalUpdate ) {
+ 
+-			this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
++			// updateMatrix() sets matrixWorldNeedsUpdate = true
++			this.updateMatrix();
++			this.matrixNeedsUpdate = false;
+ 
+ 		}
+ 
+-		// update children
++		if ( ! skipParents && this.parent ) {
+ 
+-		if ( updateChildren === true ) {
++			this.parent.updateMatrices( false, forceWorldUpdate, false );
++			this.matrixWorldNeedsUpdate = this.matrixWorldNeedsUpdate || this.parent.childrenNeedMatrixWorldUpdate;
+ 
+-			const children = this.children;
++		}
+ 
+-			for ( let i = 0, l = children.length; i < l; i ++ ) {
++		if ( this.matrixWorldNeedsUpdate || forceWorldUpdate ) {
++
++			_m2.copy( this.matrixWorld );
++
++			if ( this.parent === null ) {
++
++				this.matrixWorld.copy( this.matrix );
++
++			} else {
++
++				// If the matrix is unmodified, it is the identity matrix,
++				// and hence we can use the parent's world matrix directly.
++				//
++				// Note this assumes all callers will either not pass skipParents=true
++				// *or* will update the parent themselves beforehand as is done in
++				// updateMatrixWorld.
++				if ( ! this.matrixIsModified ) {
++
++					this.matrixWorld = this.parent.matrixWorld;
++
++				} else {
++
++					// Once matrixIsModified === true, this.matrixWorld has been updated to be a local
++					// copy, not a reference to this.parent.matrixWorld (see updateMatrix/applyMatrix)
++					this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
++
++				}
+ 
+-				children[ i ].updateWorldMatrix( false, true );
++			}
++
++			if ( _m2.near( this.matrixWorld, _epsilon ) ) {
++
++				this.matrixWorld.copy( _m2 );
++
++			} else {
++
++				this.childrenNeedMatrixWorldUpdate = true;
+ 
+ 			}
+ 
++			this.matrixWorldNeedsUpdate = false;
++
+ 		}
+ 
+ 	}
+@@ -919,6 +1043,23 @@ class Object3D extends EventDispatcher {
+ 
+ 	}
+ 
++	_handleMatrixModification() {
++
++		if ( ! this.matrixIsModified ) {
++
++			this.matrixIsModified = true;
++
++			if ( this.cachedMatrixWorld ) {
++
++				this.cachedMatrixWorld.copy( this.matrixWorld );
++				this.matrixWorld = this.cachedMatrixWorld;
++
++			}
++
++		}
++
++	}
++
+ }
+ 
+ Object3D.DefaultUp = new Vector3( 0, 1, 0 );
+diff --git a/node_modules/three/src/core/Raycaster.js b/node_modules/three/src/core/Raycaster.js
+index c4f0c37..86a8f29 100644
+--- a/node_modules/three/src/core/Raycaster.js
++++ b/node_modules/three/src/core/Raycaster.js
+@@ -87,11 +87,9 @@ function ascSort( a, b ) {
+ 
+ function intersectObject( object, raycaster, intersects, recursive ) {
+ 
+-	if ( object.layers.test( raycaster.layers ) ) {
++	if ( ! object.visible ) return;
+ 
+-		object.raycast( raycaster, intersects );
+-
+-	}
++	object.raycast( raycaster, intersects );
+ 
+ 	if ( recursive === true ) {
+ 
+diff --git a/node_modules/three/src/extras/PMREMGenerator.js b/node_modules/three/src/extras/PMREMGenerator.js
+index 9e752b9..d87d192 100644
+--- a/node_modules/three/src/extras/PMREMGenerator.js
++++ b/node_modules/three/src/extras/PMREMGenerator.js
+@@ -261,7 +261,7 @@ class PMREMGenerator {
+ 
+ 		const cubeUVRenderTarget = _createRenderTarget( width, height, params );
+ 
+-		if ( this._pingPongRenderTarget === null || this._pingPongRenderTarget.width !== width ) {
++		if ( this._pingPongRenderTarget === null || this._pingPongRenderTarget.width !== width || this._pingPongRenderTarget.height !== height ) {
+ 
+ 			if ( this._pingPongRenderTarget !== null ) {
+ 
+diff --git a/node_modules/three/src/lights/ReflectionProbe.js b/node_modules/three/src/lights/ReflectionProbe.js
+new file mode 100644
+index 0000000..6f31da3
+--- /dev/null
++++ b/node_modules/three/src/lights/ReflectionProbe.js
+@@ -0,0 +1,32 @@
++import { Box3 } from '../math/Box3.js';
++import { Light } from './Light.js';
++
++class ReflectionProbe extends Light {
++
++	constructor( box = new Box3(), texture ) {
++
++		super();
++
++		this.box = box;
++		this.texture = texture;
++
++	}
++
++	copy( source ) {
++
++		super.copy( source );
++
++		this.box.copy( source.box );
++		this.texture = source.texture;
++
++		return this;
++
++	}
++
++	// TODO fromJSON/toJSON
++
++}
++
++ReflectionProbe.prototype.isReflectionProbe = true;
++
++export { ReflectionProbe };
+diff --git a/node_modules/three/src/loaders/FileLoader.js b/node_modules/three/src/loaders/FileLoader.js
+index d9a9618..ac5dc08 100644
+--- a/node_modules/three/src/loaders/FileLoader.js
++++ b/node_modules/three/src/loaders/FileLoader.js
+@@ -3,6 +3,17 @@ import { Loader } from './Loader.js';
+ 
+ const loading = {};
+ 
++class HttpError extends Error {
++
++	constructor( message, response ) {
++
++		super( message );
++		this.response = response;
++
++	}
++
++}
++
+ class FileLoader extends Loader {
+ 
+ 	constructor( manager ) {
+@@ -19,7 +30,10 @@ class FileLoader extends Loader {
+ 
+ 		url = this.manager.resolveURL( url );
+ 
+-		const cached = Cache.get( url );
++		const isRangeRequest = this.requestHeader.Range !== undefined;
++		const key = url + ( isRangeRequest ? `:${this.requestHeader.Range}` : '' );
++
++		const cached = Cache.get( key );
+ 
+ 		if ( cached !== undefined ) {
+ 
+@@ -39,9 +53,9 @@ class FileLoader extends Loader {
+ 
+ 		// Check if request is duplicate
+ 
+-		if ( loading[ url ] !== undefined ) {
++		if ( loading[ key ] !== undefined ) {
+ 
+-			loading[ url ].push( {
++			loading[ key ].push( {
+ 
+ 				onLoad: onLoad,
+ 				onProgress: onProgress,
+@@ -54,9 +68,9 @@ class FileLoader extends Loader {
+ 		}
+ 
+ 		// Initialise array for duplicate requests
+-		loading[ url ] = [];
++		loading[ key ] = [];
+ 
+-		loading[ url ].push( {
++		loading[ key ].push( {
+ 			onLoad: onLoad,
+ 			onProgress: onProgress,
+ 			onError: onError,
+@@ -77,7 +91,7 @@ class FileLoader extends Loader {
+ 		fetch( req )
+ 			.then( response => {
+ 
+-				if ( response.status === 200 || response.status === 0 ) {
++				if ( response.status === 200 || response.status === 206 || response.status === 0 ) {
+ 
+ 					// Some browsers return HTTP Status 0 when using non-http protocol
+ 					// e.g. 'file://' or 'data://'. Handle as success.
+@@ -88,6 +102,12 @@ class FileLoader extends Loader {
+ 
+ 					}
+ 
++					if ( isRangeRequest && response.status === 200 ) {
++
++						throw new HttpError( `range request fetch for "${response.url}" responded with ${response.status}: ${response.statusText}`, response );
++
++					}
++
+ 					// Workaround: Checking if response.body === undefined for Alipay browser #23548
+ 
+ 					if ( typeof ReadableStream === 'undefined' || response.body === undefined || response.body.getReader === undefined ) {
+@@ -96,7 +116,7 @@ class FileLoader extends Loader {
+ 
+ 					}
+ 
+-					const callbacks = loading[ url ];
++					const callbacks = loading[ key ];
+ 					const reader = response.body.getReader();
+ 					const contentLength = response.headers.get( 'Content-Length' );
+ 					const total = contentLength ? parseInt( contentLength ) : 0;
+@@ -201,10 +221,10 @@ class FileLoader extends Loader {
+ 
+ 				// Add to cache only on HTTP success, so that we do not cache
+ 				// error response bodies as proper responses to requests.
+-				Cache.add( url, data );
++				Cache.add( key, data );
+ 
+-				const callbacks = loading[ url ];
+-				delete loading[ url ];
++				const callbacks = loading[ key ];
++				delete loading[ key ];
+ 
+ 				for ( let i = 0, il = callbacks.length; i < il; i ++ ) {
+ 
+@@ -218,7 +238,7 @@ class FileLoader extends Loader {
+ 
+ 				// Abort errors and other errors are handled the same
+ 
+-				const callbacks = loading[ url ];
++				const callbacks = loading[ key ];
+ 
+ 				if ( callbacks === undefined ) {
+ 
+@@ -228,7 +248,7 @@ class FileLoader extends Loader {
+ 
+ 				}
+ 
+-				delete loading[ url ];
++				delete loading[ key ];
+ 
+ 				for ( let i = 0, il = callbacks.length; i < il; i ++ ) {
+ 
+diff --git a/node_modules/three/src/math/Matrix4.js b/node_modules/three/src/math/Matrix4.js
+index 2c327f3..44eed15 100644
+--- a/node_modules/three/src/math/Matrix4.js
++++ b/node_modules/three/src/math/Matrix4.js
+@@ -831,6 +831,22 @@ class Matrix4 {
+ 
+ 	}
+ 
++	// [HUBS] Similar to equals() but allow the diff under eps.
++	near( matrix, eps = Number.EPSILON ) {
++
++		const te = this.elements;
++		const me = matrix.elements;
++
++		for ( let i = 0; i < 16; i ++ ) {
++
++			if ( Math.abs( te[ i ] - me[ i ] ) >= eps ) return false;
++
++		}
++
++		return true;
++
++	}
++
+ 	fromArray( array, offset = 0 ) {
+ 
+ 		for ( let i = 0; i < 16; i ++ ) {
+diff --git a/node_modules/three/src/math/Quaternion.js b/node_modules/three/src/math/Quaternion.js
+index 6f38435..aaf4bd1 100644
+--- a/node_modules/three/src/math/Quaternion.js
++++ b/node_modules/three/src/math/Quaternion.js
+@@ -639,6 +639,16 @@ class Quaternion {
+ 
+ 	}
+ 
++	// [HUBS] Similar to equals() but allows the diff under eps
++	near( quaternion, eps = Number.EPSILON ) {
++
++		return ( Math.abs( quaternion._x - this._x ) < eps ) &&
++			( Math.abs( quaternion._y - this._y ) < eps ) &&
++			( Math.abs( quaternion._z - this._z ) < eps ) &&
++			( Math.abs( quaternion._w - this._w ) < eps );
++
++	}
++
+ 	fromArray( array, offset = 0 ) {
+ 
+ 		this._x = array[ offset ];
+diff --git a/node_modules/three/src/math/Vector3.js b/node_modules/three/src/math/Vector3.js
+index 8ab4574..b8249e1 100644
+--- a/node_modules/three/src/math/Vector3.js
++++ b/node_modules/three/src/math/Vector3.js
+@@ -676,6 +676,15 @@ class Vector3 {
+ 
+ 	}
+ 
++	// [HUBS] Similar to equals() but allows the diff under eps
++	near( v, eps = Number.EPSILON ) {
++
++		return ( Math.abs( v.x - this.x ) < eps ) &&
++			( Math.abs( v.y - this.y ) < eps ) &&
++			( Math.abs( v.z - this.z ) < eps );
++
++	}
++
+ 	fromArray( array, offset = 0 ) {
+ 
+ 		this.x = array[ offset ];
+diff --git a/node_modules/three/src/renderers/WebGLCubeRenderTarget.js b/node_modules/three/src/renderers/WebGLCubeRenderTarget.js
+index a5a7ddd..800a13a 100644
+--- a/node_modules/three/src/renderers/WebGLCubeRenderTarget.js
++++ b/node_modules/three/src/renderers/WebGLCubeRenderTarget.js
+@@ -83,6 +83,7 @@ class WebGLCubeRenderTarget extends WebGLRenderTarget {
+ 					vec3 direction = normalize( vWorldDirection );
+ 
+ 					vec2 sampleUV = equirectUv( direction );
++					${! texture.flipY ? 'sampleUV.y = 1.0 - sampleUV.y;' : ''}
+ 
+ 					gl_FragColor = texture2D( tEquirect, sampleUV );
+ 
+diff --git a/node_modules/three/src/renderers/WebGLRenderer.js b/node_modules/three/src/renderers/WebGLRenderer.js
+index 4669da7..dd2836d 100644
+--- a/node_modules/three/src/renderers/WebGLRenderer.js
++++ b/node_modules/three/src/renderers/WebGLRenderer.js
+@@ -17,6 +17,7 @@ import { Matrix4 } from '../math/Matrix4.js';
+ import { Vector2 } from '../math/Vector2.js';
+ import { Vector3 } from '../math/Vector3.js';
+ import { Vector4 } from '../math/Vector4.js';
++import { Box3 } from '../math/Box3.js';
+ import { WebGLAnimation } from './webgl/WebGLAnimation.js';
+ import { WebGLAttributes } from './webgl/WebGLAttributes.js';
+ import { WebGLBackground } from './webgl/WebGLBackground.js';
+@@ -54,6 +55,16 @@ function createCanvasElement() {
+ 
+ }
+ 
++// non-zero here allows flat planes to still be lit by reflection probes
++// by considering them *very* thin instead of *infinitely* thin.
++function nonZeroBoxVolume( box ) {
++
++	return ( ( box.max.x - box.min.x || Number.EPSILON ) *
++			 ( box.max.y - box.min.y || Number.EPSILON ) *
++			 ( box.max.z - box.min.z || Number.EPSILON ) );
++
++}
++
+ function WebGLRenderer( parameters = {} ) {
+ 
+ 	this.isWebGLRenderer = true;
+@@ -207,6 +218,9 @@ function WebGLRenderer( parameters = {} ) {
+ 	const _vector2 = new Vector2();
+ 	const _vector3 = new Vector3();
+ 
++	const _tmpObjectAABB = new Box3();
++	const _tmpOverlapBox = new Box3();
++
+ 	const _emptyScene = { background: null, fog: null, environment: null, overrideMaterial: null, isScene: true };
+ 
+ 	function getTargetPixelRatio() {
+@@ -1207,6 +1221,14 @@ function WebGLRenderer( parameters = {} ) {
+ 
+ 		currentRenderState.setupLightsView( camera );
+ 
++		// TODO this triggers cubemap generation up front, should probably be done elsewhere
++		const reflectionProbes = currentRenderState.state.lights.state.reflectionProbes;
++		for ( let i = 0; i < reflectionProbes.length; i ++ ) {
++
++			cubeuvmaps.get( reflectionProbes[ i ].texture );
++
++		}
++
+ 		if ( transmissiveObjects.length > 0 ) renderTransmissionPass( opaqueObjects, scene, camera );
+ 
+ 		if ( viewport ) state.viewport( _currentViewport.copy( viewport ) );
+@@ -1715,6 +1737,90 @@ function WebGLRenderer( parameters = {} ) {
+ 
+ 		}
+ 
++		// This is not done in refreshMaterialUniforms because we want to be able to support the same material using different environment map (based on its location)
++		// Because of this, similar to the above note about skinned meshes, this must be done before refreshMaterialUniforms is called, and both texture uniforms must
++		// be set in all cases to prevent texture units from becoming out of sync when refreshMaterials is not set and thus refreshMaterialUniforms is not called.
++		if ( materialProperties.envMap && material.isMeshStandardMaterial ) {
++
++			const probes = lights.state.reflectionProbes;
++
++			// this is essentially the same as the original codepath without ReflectionProbes, with the addition of setting envMap2 and envMapBlend to noop values
++			if ( material.envMap || ! probes.length || ! object.reflectionProbeMode ) {
++
++				p_uniforms.setValue( _gl, 'envMap', materialProperties.envMap, textures );
++				p_uniforms.setValue( _gl, 'envMap2', materialProperties.envMap, textures );
++				p_uniforms.setValue( _gl, 'envMapBlend', 0 );
++
++			} else if ( object.reflectionProbeMode === 'static' && object.__webglStaticReflectionProbe ) {
++
++				p_uniforms.setValue( _gl, 'envMap', object.__webglStaticReflectionProbe.envMap, textures );
++				p_uniforms.setValue( _gl, 'envMap2', object.__webglStaticReflectionProbe.envMap2, textures );
++				p_uniforms.setValue( _gl, 'envMapBlend', object.__webglStaticReflectionProbe.envMapBlend );
++
++			} else {
++
++				if ( ! geometry.boundingBox ) {
++
++					console.log( 'generated bounding box for ', object.name );
++					geometry.computeBoundingBox();
++
++				}
++
++				_tmpObjectAABB.copy( geometry.boundingBox ).applyMatrix4( object.matrixWorld );
++
++				let envMapA = null;
++				let envMapB = null;
++				let maxVolumeA = 0;
++				let maxVolumeB = 0;
++
++				for ( let i = 0; i < probes.length; i ++ ) {
++
++					if ( probes[ i ].box.intersectsBox( _tmpObjectAABB ) ) {
++
++						const volume = nonZeroBoxVolume( _tmpOverlapBox.copy( _tmpObjectAABB ).intersect( probes[ i ].box ) );
++						if ( volume > maxVolumeA ) {
++
++							envMapB = envMapA;
++							maxVolumeB = maxVolumeA;
++							envMapA = probes[ i ].texture;
++							maxVolumeA = volume;
++
++						} else if ( volume > maxVolumeB ) {
++
++							envMapB = probes[ i ].texture;
++							maxVolumeB = volume;
++
++						}
++
++					}
++
++				}
++
++				const blend = envMapB ?
++					  maxVolumeB / ( maxVolumeA + maxVolumeB ) :
++					  1 - ( maxVolumeA / nonZeroBoxVolume( _tmpObjectAABB ) );
++
++				envMapA = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( envMapA || environment );
++				envMapB = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( envMapB || environment );
++
++				p_uniforms.setValue( _gl, 'envMap', envMapA, textures );
++				p_uniforms.setValue( _gl, 'envMap2', envMapB, textures );
++				p_uniforms.setValue( _gl, 'envMapBlend', blend );
++
++				if ( object.reflectionProbeMode === 'static' ) {
++
++					object.__webglStaticReflectionProbe = {
++						envMap: envMapA,
++						envMap2: envMapB,
++						envMapBlend: blend
++					};
++
++				}
++
++			}
++
++		}
++
+ 		const morphAttributes = geometry.morphAttributes;
+ 
+ 		if ( morphAttributes.position !== undefined || morphAttributes.normal !== undefined || ( morphAttributes.color !== undefined && capabilities.isWebGL2 === true ) ) {
+@@ -1734,6 +1840,7 @@ function WebGLRenderer( parameters = {} ) {
+ 		if ( refreshMaterial ) {
+ 
+ 			p_uniforms.setValue( _gl, 'toneMappingExposure', _this.toneMappingExposure );
++			p_uniforms.setValue( _gl, 'tonemappingLUT', _this.tonemappingLUT, textures );
+ 
+ 			if ( materialProperties.needsLights ) {
+ 
+diff --git a/node_modules/three/src/renderers/shaders/ShaderChunk/envmap_common_pars_fragment.glsl.js b/node_modules/three/src/renderers/shaders/ShaderChunk/envmap_common_pars_fragment.glsl.js
+index cbe76d2..7b67b74 100644
+--- a/node_modules/three/src/renderers/shaders/ShaderChunk/envmap_common_pars_fragment.glsl.js
++++ b/node_modules/three/src/renderers/shaders/ShaderChunk/envmap_common_pars_fragment.glsl.js
+@@ -4,10 +4,13 @@ export default /* glsl */`
+ 	uniform float envMapIntensity;
+ 	uniform float flipEnvMap;
+ 
++	uniform float envMapBlend;
++
+ 	#ifdef ENVMAP_TYPE_CUBE
+ 		uniform samplerCube envMap;
+ 	#else
+ 		uniform sampler2D envMap;
++		uniform sampler2D envMap2;
+ 	#endif
+ 	
+ #endif
+diff --git a/node_modules/three/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js b/node_modules/three/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
+index 17461ba..144acb9 100644
+--- a/node_modules/three/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
++++ b/node_modules/three/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
+@@ -8,6 +8,9 @@ export default /* glsl */`
+ 			vec3 worldNormal = inverseTransformDirection( normal, viewMatrix );
+ 
+ 			vec4 envMapColor = textureCubeUV( envMap, worldNormal, 1.0 );
++			vec4 envMap2Color = textureCubeUV( envMap2, worldNormal, 1.0 );
++
++			envMapColor = mix(envMapColor, envMap2Color, envMapBlend);
+ 
+ 			return PI * envMapColor.rgb * envMapIntensity;
+ 
+@@ -31,6 +34,9 @@ export default /* glsl */`
+ 			reflectVec = inverseTransformDirection( reflectVec, viewMatrix );
+ 
+ 			vec4 envMapColor = textureCubeUV( envMap, reflectVec, roughness );
++			vec4 envMap2Color = textureCubeUV( envMap2, reflectVec, roughness );
++
++			envMapColor = mix(envMapColor, envMap2Color, envMapBlend);
+ 
+ 			return envMapColor.rgb * envMapIntensity;
+ 
+diff --git a/node_modules/three/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js b/node_modules/three/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
+index 940f1d3..9419c97 100644
+--- a/node_modules/three/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
++++ b/node_modules/three/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
+@@ -10,7 +10,7 @@ export default /* glsl */`
+ 
+ 	#endif
+ 
+-	#if defined( USE_ENVMAP ) && defined( STANDARD ) && defined( ENVMAP_TYPE_CUBE_UV )
++	#if defined( USE_ENVMAP ) && defined( STANDARD ) && defined( ENVMAP_TYPE_CUBE_UV ) && !defined(USE_LIGHTMAP)
+ 
+ 		iblIrradiance += getIBLIrradiance( geometry.normal );
+ 
+diff --git a/node_modules/three/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js b/node_modules/three/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
+index 5087a83..ba833db 100644
+--- a/node_modules/three/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
++++ b/node_modules/three/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
+@@ -73,5 +73,31 @@ vec3 ACESFilmicToneMapping( vec3 color ) {
+ 
+ }
+ 
++// Use a 3D LUT to perform tone mapping
++
++#ifdef LUT_TONE_MAPPING
++
++	precision highp sampler3D;
++	uniform sampler3D tonemappingLUT;
++
++	vec3 LUTToneMapping( vec3 color ) {
++
++		// Match Blender's exposure curve
++		// color *= pow(2.0, toneMappingExposure);
++
++		color *= toneMappingExposure;
++
++		// TODO don't hardcode this
++		float lutSize = 32.0;
++		float pixelWidth = 1.0 / lutSize;
++		float halfPixelWidth = 0.5 / lutSize;
++		vec3 uvw = vec3( halfPixelWidth ) + color.rgb * ( 1.0 - pixelWidth );
++
++		return texture( tonemappingLUT, uvw ).rgb;
++
++	}
++
++#endif
++
+ vec3 CustomToneMapping( vec3 color ) { return color; }
+ `;
+diff --git a/node_modules/three/src/renderers/shaders/ShaderLib.js b/node_modules/three/src/renderers/shaders/ShaderLib.js
+index 126df13..9e19b5f 100644
+--- a/node_modules/three/src/renderers/shaders/ShaderLib.js
++++ b/node_modules/three/src/renderers/shaders/ShaderLib.js
+@@ -75,7 +75,13 @@ const ShaderLib = {
+ 
+ 		uniforms: mergeUniforms( [
+ 			UniformsLib.common,
+-			UniformsLib.envmap,
++			( () => {
++
++				// TODO HACK don't include envMap uniform, it is currently handling directly in WebGLRenderer for ReflectionProbes support
++				const { envMap, ...rest } = UniformsLib.envmap; // eslint-disable-line no-unused-vars
++				return rest;
++
++			} )(),
+ 			UniformsLib.aomap,
+ 			UniformsLib.lightmap,
+ 			UniformsLib.emissivemap,
+diff --git a/node_modules/three/src/renderers/webgl/WebGLLights.js b/node_modules/three/src/renderers/webgl/WebGLLights.js
+index 7e7f0ce..0857430 100644
+--- a/node_modules/three/src/renderers/webgl/WebGLLights.js
++++ b/node_modules/three/src/renderers/webgl/WebGLLights.js
+@@ -174,6 +174,7 @@ function WebGLLights( extensions, capabilities ) {
+ 
+ 		ambient: [ 0, 0, 0 ],
+ 		probe: [],
++		reflectionProbes: [],
+ 		directional: [],
+ 		directionalShadow: [],
+ 		directionalShadowMap: [],
+@@ -215,6 +216,8 @@ function WebGLLights( extensions, capabilities ) {
+ 		let numPointShadows = 0;
+ 		let numSpotShadows = 0;
+ 
++		let numReflectionProbes = 0;
++
+ 		lights.sort( shadowCastingLightsFirst );
+ 
+ 		// artist-friendly light intensity scaling factor
+@@ -244,6 +247,10 @@ function WebGLLights( extensions, capabilities ) {
+ 
+ 				}
+ 
++			} else if ( light.isReflectionProbe ) {
++
++				state.reflectionProbes[ numReflectionProbes ++ ] = light;
++
+ 			} else if ( light.isDirectionalLight ) {
+ 
+ 				const uniforms = cache.get( light );
+@@ -411,6 +418,8 @@ function WebGLLights( extensions, capabilities ) {
+ 		state.ambient[ 1 ] = g;
+ 		state.ambient[ 2 ] = b;
+ 
++		state.reflectionProbes.length = numReflectionProbes;
++
+ 		const hash = state.hash;
+ 
+ 		if ( hash.directionalLength !== directionalLength ||
+diff --git a/node_modules/three/src/renderers/webgl/WebGLMaterials.js b/node_modules/three/src/renderers/webgl/WebGLMaterials.js
+index 188aa81..24d0d4f 100644
+--- a/node_modules/three/src/renderers/webgl/WebGLMaterials.js
++++ b/node_modules/three/src/renderers/webgl/WebGLMaterials.js
+@@ -173,7 +173,12 @@ function WebGLMaterials( renderer, properties ) {
+ 
+ 		if ( envMap ) {
+ 
+-			uniforms.envMap.value = envMap;
++			// TODO HACK currently handling directly in WebGLRenderer only for MeshStandardMaterial for ReflectionProbes
++			if ( ! material.isMeshStandardMaterial ) {
++
++				uniforms.envMap.value = envMap;
++
++			}
+ 
+ 			uniforms.flipEnvMap.value = ( envMap.isCubeTexture && envMap.isRenderTargetTexture === false ) ? - 1 : 1;
+ 
+diff --git a/node_modules/three/src/renderers/webgl/WebGLMorphtargets.js b/node_modules/three/src/renderers/webgl/WebGLMorphtargets.js
+index b8d5fe6..f43bb48 100644
+--- a/node_modules/three/src/renderers/webgl/WebGLMorphtargets.js
++++ b/node_modules/three/src/renderers/webgl/WebGLMorphtargets.js
+@@ -48,7 +48,7 @@ function WebGLMorphtargets( gl, capabilities, textures ) {
+ 
+ 		const objectInfluences = object.morphTargetInfluences;
+ 
+-		if ( capabilities.isWebGL2 === true ) {
++		if ( capabilities.isWebGL2 === true && false /* casuing issues, disable for now, also see WebGLProgram */ ) {
+ 
+ 			// instead of using attributes, the WebGL 2 code path encodes morph targets
+ 			// into an array of data textures. Each layer represents a single morph target.
+diff --git a/node_modules/three/src/renderers/webgl/WebGLProgram.js b/node_modules/three/src/renderers/webgl/WebGLProgram.js
+index 5e9ee69..80b13ed 100644
+--- a/node_modules/three/src/renderers/webgl/WebGLProgram.js
++++ b/node_modules/three/src/renderers/webgl/WebGLProgram.js
+@@ -1,7 +1,7 @@
+ import { WebGLUniforms } from './WebGLUniforms.js';
+ import { WebGLShader } from './WebGLShader.js';
+ import { ShaderChunk } from '../shaders/ShaderChunk.js';
+-import { NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, ACESFilmicToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, sRGBEncoding, LinearEncoding, GLSL3 } from '../../constants.js';
++import { NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, ACESFilmicToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, sRGBEncoding, LinearEncoding, GLSL3, LUTToneMapping } from '../../constants.js';
+ 
+ let programIdCount = 0;
+ 
+@@ -97,6 +97,10 @@ function getToneMappingFunction( functionName, toneMapping ) {
+ 			toneMappingName = 'Custom';
+ 			break;
+ 
++		case LUTToneMapping:
++			toneMappingName = 'LUT';
++			break;
++
+ 		default:
+ 			console.warn( 'THREE.WebGLProgram: Unsupported toneMapping:', toneMapping );
+ 			toneMappingName = 'Linear';
+@@ -511,10 +515,13 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
+ 
+ 			parameters.morphTargets ? '#define USE_MORPHTARGETS' : '',
+ 			parameters.morphNormals && parameters.flatShading === false ? '#define USE_MORPHNORMALS' : '',
+-			( parameters.morphColors && parameters.isWebGL2 ) ? '#define USE_MORPHCOLORS' : '',
+-			( parameters.morphTargetsCount > 0 && parameters.isWebGL2 ) ? '#define MORPHTARGETS_TEXTURE' : '',
+-			( parameters.morphTargetsCount > 0 && parameters.isWebGL2 ) ? '#define MORPHTARGETS_TEXTURE_STRIDE ' + parameters.morphTextureStride : '',
+-			( parameters.morphTargetsCount > 0 && parameters.isWebGL2 ) ? '#define MORPHTARGETS_COUNT ' + parameters.morphTargetsCount : '',
++
++			// This causes issues on some systems, disable for now
++			// ( parameters.morphColors && parameters.isWebGL2 ) ? '#define USE_MORPHCOLORS' : '',
++			// ( parameters.morphTargetsCount > 0 && parameters.isWebGL2 ) ? '#define MORPHTARGETS_TEXTURE' : '',
++			// ( parameters.morphTargetsCount > 0 && parameters.isWebGL2 ) ? '#define MORPHTARGETS_TEXTURE_STRIDE ' + parameters.morphTextureStride : '',
++			// ( parameters.morphTargetsCount > 0 && parameters.isWebGL2 ) ? '#define MORPHTARGETS_COUNT ' + parameters.morphTargetsCount : '',
++
+ 			parameters.doubleSided ? '#define DOUBLE_SIDED' : '',
+ 			parameters.flipSided ? '#define FLIP_SIDED' : '',
+ 
+@@ -688,6 +695,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
+ 			'uniform bool isOrthographic;',
+ 
+ 			( parameters.toneMapping !== NoToneMapping ) ? '#define TONE_MAPPING' : '',
++			( parameters.toneMapping === LUTToneMapping ) ? '#define LUT_TONE_MAPPING' : '',
+ 			( parameters.toneMapping !== NoToneMapping ) ? ShaderChunk[ 'tonemapping_pars_fragment' ] : '', // this code is required here because it is used by the toneMapping() function defined below
+ 			( parameters.toneMapping !== NoToneMapping ) ? getToneMappingFunction( 'toneMapping', parameters.toneMapping ) : '',
+ 
+diff --git a/node_modules/three/src/renderers/webgl/WebGLState.js b/node_modules/three/src/renderers/webgl/WebGLState.js
+index dff3fb2..85fd4c6 100644
+--- a/node_modules/three/src/renderers/webgl/WebGLState.js
++++ b/node_modules/three/src/renderers/webgl/WebGLState.js
+@@ -928,11 +928,27 @@ function WebGLState( gl, extensions, capabilities ) {
+ 
+ 	}
+ 
+-	function compressedTexImage2D() {
++	function compressedTexImage2D( a, b, c, d, e, f, g, h, i, j ) {
+ 
+ 		try {
+ 
+-			gl.compressedTexImage2D.apply( gl, arguments );
++			if ( h === undefined ) {
++
++				gl.compressedTexImage2D( a, b, c, d, e, f, g );
++
++			} else if ( i === undefined ) {
++
++				gl.compressedTexImage2D( a, b, c, d, e, f, g, h );
++
++			} else if ( j === undefined ) {
++
++				gl.compressedTexImage2D( a, b, c, d, e, f, g, h, i );
++
++			} else {
++
++				gl.compressedTexImage2D( a, b, c, d, e, f, g, h, i, j );
++
++			}
+ 
+ 		} catch ( error ) {
+ 
+@@ -1012,11 +1028,19 @@ function WebGLState( gl, extensions, capabilities ) {
+ 
+ 	}
+ 
+-	function texImage2D() {
++	function texImage2D( a, b, c, d, e, f, g, h, i ) {
+ 
+ 		try {
+ 
+-			gl.texImage2D.apply( gl, arguments );
++			if ( g === undefined ) {
++
++				gl.texImage2D( a, b, c, d, e, f );
++
++			} else {
++
++				gl.texImage2D( a, b, c, d, e, f, g, h, i );
++
++			}
+ 
+ 		} catch ( error ) {
+ 
+@@ -1026,11 +1050,19 @@ function WebGLState( gl, extensions, capabilities ) {
+ 
+ 	}
+ 
+-	function texImage3D() {
++	function texImage3D( a, b, c, d, e, f, g, h, i, j, k ) {
+ 
+ 		try {
+ 
+-			gl.texImage3D.apply( gl, arguments );
++			if ( k === undefined ) {
++
++				gl.texImage3D( a, b, c, d, e, f, g, h, i, j );
++
++			} else {
++
++				gl.texImage3D( a, b, c, d, e, f, g, h, i, j, k );
++
++			}
+ 
+ 		} catch ( error ) {
+ 
+diff --git a/node_modules/three/src/renderers/webxr/WebXRManager.js b/node_modules/three/src/renderers/webxr/WebXRManager.js
+index 308be47..3539221 100644
+--- a/node_modules/three/src/renderers/webxr/WebXRManager.js
++++ b/node_modules/three/src/renderers/webxr/WebXRManager.js
+@@ -506,6 +506,8 @@ class WebXRManager extends EventDispatcher {
+ 			camera.quaternion.copy( cameraVR.quaternion );
+ 			camera.scale.copy( cameraVR.scale );
+ 			camera.matrix.copy( cameraVR.matrix );
++			camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
++
+ 			camera.matrixWorld.copy( cameraVR.matrixWorld );
+ 
+ 			const children = camera.children;

--- a/src/bit-systems/network-receive-system.ts
+++ b/src/bit-systems/network-receive-system.ts
@@ -5,7 +5,7 @@ import { renderAsNetworkedEntity } from "../utils/create-networked-entity";
 import { createEntityState, deleteEntityState, hasSavedEntityState } from "../utils/entity-state-utils";
 import { networkableComponents, schemas, StoredComponent } from "../utils/network-schemas";
 import type { ClientID, CursorBufferUpdateMessage, EntityID, StringID, UpdateMessage } from "../utils/networking-types";
-import { hasPermissionToSpawn } from "../utils/permissions";
+import { canManipulateNetworkedEntity, hasPermissionToSpawn } from "../utils/permissions";
 import { takeSoftOwnership } from "../utils/take-soft-ownership";
 import {
   connectedClientIds,
@@ -211,6 +211,10 @@ export function networkReceiveSystem(world: HubsWorld) {
         // Can we use connectedClientIds / disconnectedClientIds / and the nid prefix to figure this out?
         // TODO It would be nice if we could squash these updates
         const updates = storedUpdates.get(nid) || [];
+        // [Security] Preserve the attributed sender so the authorization guard below still
+        // runs when this update is replayed after the entity is instantiated. Without this, a
+        // peer could bypass the check by racing its (takeover) update ahead of the create.
+        updateMessage.fromClientId = message.fromClientId;
         updates.push(updateMessage);
         storedUpdates.set(nid, updates);
         continue;
@@ -219,6 +223,21 @@ export function networkReceiveSystem(world: HubsWorld) {
       const eid = world.nid2eid.get(nid)!;
 
       if (isOutdatedMessage(eid, updateMessage)) {
+        continue;
+      }
+
+      // [Security] Reject updates from senders who lack permission to manipulate this entity.
+      // Each client enforces this independently against the server-attributed sender id, so a
+      // maliciously modified peer cannot take ownership of (or mutate) objects in other
+      // participants' views. Authoritative enforcement still belongs in Reticulum; this is
+      // defense-in-depth and mirrors the permission check on the create path above.
+      // `message.fromClientId` is present for live messages; replayed stored updates carry the
+      // attribution on the update itself (see the store branch above).
+      const sender = message.fromClientId ?? updateMessage.fromClientId;
+      if (sender && !canManipulateNetworkedEntity(sender, eid)) {
+        console.warn(
+          `Ignoring unauthorized update for ${updateMessage.nid} from client ${sender} (insufficient permissions).`
+        );
         continue;
       }
 

--- a/src/utils/authorize-entity-manipulation.js
+++ b/src/utils/authorize-entity-manipulation.js
@@ -1,0 +1,34 @@
+// Authorization core shared by the networking receive paths.
+//
+// This module is intentionally dependency-free so it can be unit tested in
+// isolation (see test/unit/utils/authorize-entity-manipulation.test.js) and
+// reused by both the legacy NAF receive path and the bitECS receive path.
+//
+// A networked entity may be manipulated (moved, mutated, re-owned or removed)
+// by `sender` when ALL of the following hold:
+//   - the update originates from reticulum (server authoritative), OR the
+//     sender created the entity, OR the sender holds the permission required to
+//     spawn/move that kind of entity; AND
+//   - if the entity is pinned, the sender additionally holds `pin_objects`.
+//
+// This mirrors the rule already enforced for the legacy NAF path in
+// permissions-utils.js (`authorizeEntityManipulation`) and the spawn-time check
+// in permissions.ts (`hasPermissionToSpawn`).
+//
+// `userCan(clientId, permission)` is injected and must return a boolean. Keeping
+// it as a parameter avoids any dependency on the hub channel / presence state so
+// the rule can be exercised deterministically in tests.
+//
+// NOTE: This is a defense-in-depth control. Because every client evaluates it
+// independently against the server-attributed sender id, a maliciously modified
+// peer cannot make honest clients accept an ownership/manipulation it is not
+// entitled to. It does NOT replace authoritative enforcement in Reticulum.
+
+export function authorizeEntityManipulation({ sender, isCreator, isPinned, manipulatePermission }, userCan) {
+  if (sender === "reticulum") return true;
+
+  const pinnedOk = !isPinned || userCan(sender, "pin_objects");
+  const manipulateOk = isCreator || userCan(sender, manipulatePermission);
+
+  return pinnedOk && manipulateOk;
+}

--- a/src/utils/networking-types.ts
+++ b/src/utils/networking-types.ts
@@ -25,6 +25,10 @@ export interface UpdateMessageBase {
   lastOwnerTime: number;
   timestamp: number;
   owner: ClientID;
+  // Server-attributed id of the peer that sent this update. Set from the message's
+  // from_session_id on receipt; preserved on stored updates so the authorization
+  // guard can run when a delayed update is replayed after its create.
+  fromClientId?: ClientID;
 }
 export interface CursorBufferUpdateMessage extends UpdateMessageBase {
   componentIds: number[];

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,8 +1,37 @@
 import { PrefabName, prefabs } from "../prefabs/prefabs";
-import type { ClientID } from "./networking-types";
+import { Networked } from "../bit-components";
+import { createMessageDatas, isPinned } from "../bit-systems/networking";
+import { authorizeEntityManipulation } from "./authorize-entity-manipulation";
+import type { ClientID, EntityID } from "./networking-types";
 
 export function hasPermissionToSpawn(creator: ClientID, prefabName: PrefabName) {
   if (creator === "reticulum") return true;
   const perm = prefabs.get(prefabName)!.permission;
   return APP.hubChannel!.userCan(creator, perm);
+}
+
+// Defense-in-depth check for the bitECS receive path. Returns true if `sender`
+// is allowed to take ownership of / mutate the given network-instantiated entity.
+//
+// This mirrors `hasPermissionToSpawn` (and the legacy NAF
+// `authorizeEntityManipulation`): a peer must not be able to claim ownership of,
+// or mutate, an object that it would not have been allowed to spawn or move in
+// the first place. Without this, any peer can broadcast an update message that
+// claims ownership of any networked object.
+//
+// Entities that were not instantiated through the bitECS networking path (no
+// CreateMessageData) are left to other checks and are not blocked here.
+export function canManipulateNetworkedEntity(sender: ClientID, eid: EntityID): boolean {
+  if (sender === "reticulum") return true;
+
+  const data = createMessageDatas.get(eid);
+  if (!data) return true;
+
+  const prefab = prefabs.get(data.prefabName)!;
+  const isCreator = Networked.creator[eid] === APP.getSid(sender);
+
+  return authorizeEntityManipulation(
+    { sender, isCreator, isPinned: isPinned(eid), manipulatePermission: prefab.permission },
+    (clientId: ClientID, permission: string) => APP.hubChannel!.userCan(clientId, permission)
+  );
 }

--- a/test/unit/utils/authorize-entity-manipulation.test.js
+++ b/test/unit/utils/authorize-entity-manipulation.test.js
@@ -1,0 +1,110 @@
+import test from "ava";
+import { authorizeEntityManipulation } from "../../../src/utils/authorize-entity-manipulation";
+
+// Helper: build a userCan(clientId, permission) backed by a plain map of granted permissions.
+function userCanFor(granted) {
+  return (clientId, permission) => !!(granted[clientId] && granted[clientId][permission]);
+}
+
+const NOBODY_CAN = () => false;
+
+test("reticulum is always authorized, even with no permissions", t => {
+  t.true(
+    authorizeEntityManipulation(
+      { sender: "reticulum", isCreator: false, isPinned: true, manipulatePermission: "spawn_and_move_media" },
+      NOBODY_CAN
+    )
+  );
+});
+
+test("creator may manipulate their own (unpinned) entity without the move permission", t => {
+  t.true(
+    authorizeEntityManipulation(
+      { sender: "alice", isCreator: true, isPinned: false, manipulatePermission: "spawn_and_move_media" },
+      NOBODY_CAN
+    )
+  );
+});
+
+test("non-creator without the move permission is denied (the takeover vector)", t => {
+  t.false(
+    authorizeEntityManipulation(
+      { sender: "mallory", isCreator: false, isPinned: false, manipulatePermission: "spawn_and_move_media" },
+      NOBODY_CAN
+    )
+  );
+});
+
+test("non-creator with the move permission is allowed for an unpinned entity", t => {
+  const userCan = userCanFor({ bob: { spawn_and_move_media: true } });
+  t.true(
+    authorizeEntityManipulation(
+      { sender: "bob", isCreator: false, isPinned: false, manipulatePermission: "spawn_and_move_media" },
+      userCan
+    )
+  );
+});
+
+test("pinned entity additionally requires pin_objects", t => {
+  // Has move permission but NOT pin_objects -> denied because the entity is pinned.
+  const moveOnly = userCanFor({ bob: { spawn_and_move_media: true } });
+  t.false(
+    authorizeEntityManipulation(
+      { sender: "bob", isCreator: false, isPinned: true, manipulatePermission: "spawn_and_move_media" },
+      moveOnly
+    )
+  );
+
+  // Has both move permission and pin_objects -> allowed.
+  const moveAndPin = userCanFor({ bob: { spawn_and_move_media: true, pin_objects: true } });
+  t.true(
+    authorizeEntityManipulation(
+      { sender: "bob", isCreator: false, isPinned: true, manipulatePermission: "spawn_and_move_media" },
+      moveAndPin
+    )
+  );
+});
+
+test("creator of a pinned entity still needs pin_objects to manipulate it", t => {
+  // isCreator satisfies the manipulate clause, but pinned still requires pin_objects.
+  t.false(
+    authorizeEntityManipulation(
+      { sender: "alice", isCreator: true, isPinned: true, manipulatePermission: "spawn_and_move_media" },
+      NOBODY_CAN
+    )
+  );
+  const withPin = userCanFor({ alice: { pin_objects: true } });
+  t.true(
+    authorizeEntityManipulation(
+      { sender: "alice", isCreator: true, isPinned: true, manipulatePermission: "spawn_and_move_media" },
+      withPin
+    )
+  );
+});
+
+test("the manipulate permission is specific to the prefab kind", t => {
+  // A user who may move media but not spawn cameras cannot take over a camera entity.
+  const mediaOnly = userCanFor({ bob: { spawn_and_move_media: true } });
+  t.false(
+    authorizeEntityManipulation(
+      { sender: "bob", isCreator: false, isPinned: false, manipulatePermission: "spawn_camera" },
+      mediaOnly
+    )
+  );
+  const cameraOk = userCanFor({ bob: { spawn_camera: true } });
+  t.true(
+    authorizeEntityManipulation(
+      { sender: "bob", isCreator: false, isPinned: false, manipulatePermission: "spawn_camera" },
+      cameraOk
+    )
+  );
+});
+
+test("a user with no presence/permissions (userCan always false) cannot manipulate others' entities", t => {
+  t.false(
+    authorizeEntityManipulation(
+      { sender: "ghost", isCreator: false, isPinned: false, manipulatePermission: "spawn_and_move_media" },
+      NOBODY_CAN
+    )
+  );
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -296,7 +296,12 @@ module.exports = async (env, argv) => {
         // but they are "smart" and have builds for both ESM and CJS depending on if import or require is used.
         // This forces the ESM version to be used otherwise we end up with multiple instances of the libraries,
         // and for example AFRAME.THREE.Object3D !== THREE.Object3D in Hubs code, which breaks many things.
-        three$: path.resolve(__dirname, "./node_modules/three/build/three.module.js"),
+        // Consume upstream `three` (integrity-pinned via package-lock) plus an auditable
+        // patch-package stack (patches/three+0.141.0.patch) instead of an opaque prebuilt fork.
+        // Aliasing to the ESM source entry point (rather than build/three.module.js) ensures the
+        // patched sources are what gets bundled, while still resolving every bare `three` import to
+        // a single instance (so AFRAME.THREE.Object3D === THREE.Object3D holds).
+        three$: path.resolve(__dirname, "./node_modules/three/src/Three.js"),
         bitecs$: path.resolve(__dirname, "./node_modules/bitecs/dist/index.mjs"),
 
         // UMD libraries that need explicit module resolution to work with ES6 imports


### PR DESCRIPTION
## Summary

Maintenance + robustness pass on the rendering dependency and the networking layer.

### three.js: vendored fork → upstream + patch-package
- Replaces `github:hubs-foundation/three.js#65b5105…` (an opaque, prebuilt fork) with upstream `three@0.141.0` plus an auditable patch stack applied via `patch-package` (`patches/three+0.141.0.patch`).
- Verified that the patch reproduces the fork's sources exactly, and that those sources build **byte-for-byte** to the previously shipped `build/three.module.js`. No behavior change — the fork is now fully transparent and future three.js upgrades become tractable.
- `three$` now aliases to the patched ESM source so the patches are what webpack bundles (the single-`three`-instance invariant is preserved).
- Adds `patch-package` (+ `postinstall-postinstall`) and a `postinstall` hook; lockfile updated to the integrity-pinned upstream release.

### Networking: validate entity update messages
- The bitECS receive path applied incoming entity *update* messages after only an ordering check. Added `canManipulateNetworkedEntity` (mirrors the legacy NAF `authorizeEntityManipulation` and the existing create-path permission check) so updates from senders without the relevant permission are dropped on every client. Pure logic extracted to `authorize-entity-manipulation.js` and unit-tested.

### Docs
- Adds `doc/security-analysis-2026-06.md` with the dependency/transparency analysis and recommended follow-ups (including a separate next-wave dependency update pass).

## Verification
- three.js patch rebase verified against upstream r141; new unit tests pass (`test/unit/utils/authorize-entity-manipulation.test.js`).
- Lockfile regenerated (lock-only); please run `npm install` + `npm run build` in CI to exercise the bundling-from-source path before merge.
