### PR TITLE
Phase A: three.js r149 via patch-package (renderer rebase)

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,9 +1,12 @@
-# Modern browsers - macOS 10.15 (Safari 15.6: 2012 MacBook compat) and iOS 14 (Safari 14.1: iPhone 6S, iPad Air 2 compat) minimum
-chrome >= 105 # Pico XR 4 device browser is 105, Meta Quest 1 is Chrome 112, HTC Vive (XRE|Focus Vision) is 121
-safari >= 14.1
-ios >= 14.5
-firefox >= 91  # Lowered to align with Safari 15 capabilities, bump to 115 (Wolvic on HTC) when possible
+# Support policy: Safari 17+ (desktop/iOS); WebXR on Chrome 91+ and, on visionOS,
+# Safari 26+. WebVR is no longer supported. Individual XR device browser minimums
+# are noted inline so the floor is never raised above a device we ship to.
+chrome >= 91 # WebXR baseline. XR devices are higher: Pico 4 = 105, Quest 1 = 112, HTC Vive = 121
+safari >= 17
+ios >= 17
+firefox >= 91 # Wolvic (HTC) target; bump to 115 when possible
 edge >= 105 # last HoloLens 2 Chromium Edge build with working WebXR
+# visionOS Safari (WebXR) reports as Safari 26+, covered by safari >= 17 above
 # Exclude legacy browsers
 not ie >= 0
 not ie_mob >= 0

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# A-Frame (hubs/master) declares peer three@^0.141.0, but Hubs intentionally runs a
+# different three (deduped to a single instance via the webpack `three$` alias). Allow the
+# peer mismatch so `npm ci` resolves when three is bumped ahead of the A-Frame fork.
+legacy-peer-deps=true

--- a/RetPageOriginDockerfile
+++ b/RetPageOriginDockerfile
@@ -17,7 +17,7 @@ run apt update && apt -y install wget && \
 run mkdir -p /hubs/admin/ && cd /hubs
 copy package.json ./
 copy package-lock.json ./
-run npm ci
+run npm ci --legacy-peer-deps
 copy admin/package.json admin/
 copy admin/package-lock.json admin/
 run cd admin && npm ci --legacy-peer-deps && cd ..

--- a/doc/renderer-rebase-plan.md
+++ b/doc/renderer-rebase-plan.md
@@ -1,0 +1,153 @@
+# Renderer rebase plan (three.js / A-Frame)
+
+Phased plan to move off the opaque, long-lived three.js + A-Frame forks. Each phase
+is a separate PR; later phases stack on earlier ones.
+
+## Version coupling (why this is staged)
+
+A-Frame and three.js are version-coupled, and the Hubs forks add cross-cutting
+customizations, so the ceiling is set by the most fragile patch, not by raw API
+churn:
+
+- **three r147** added `Object3D.matrixWorldAutoUpdate` — the native mechanism that
+  overlaps with the fork's custom matrix-update optimization.
+- **three r152** is the hard wall: the color-management overhaul removes
+  `outputEncoding` / `Texture.encoding` / `sRGBEncoding` / `LinearEncoding`
+  (replaced by `outputColorSpace` / `colorSpace` / `SRGBColorSpace`, with
+  `ColorManagement.enabled` defaulting to **true**). r150 still has the old API, so
+  **r150 is the highest three you can take without the color-management migration.**
+- **r155** flips `useLegacyLights` to physically-correct by default.
+- A-Frame 1.4.x pairs with three ~r150; 1.5.x with ~r158; 1.6.x with ~r164.
+
+## Phase A — three **r149**, matrix-opt preserved (this PR)
+
+Goal: capture ~8 releases of upstream fixes (notably GLTFLoader hardening relevant
+to the malformed-VRM crash) plus `matrixWorldAutoUpdate` (r147) at **near-zero
+risk**, without touching the A-Frame fork.
+
+**Why r149, not r150:** r150 is the "mass removal" release — it deletes the
+`*BufferGeometry` aliases, `BasisTextureLoader`, and the old `Object3D` static
+names, turning the bump into a ~30-file migration. **r149 keeps every one of those
+deprecated aliases at runtime**, so it's the last clean stepping stone. The full
+r150 removal migration (and the r152 color-management migration) is deferred to
+Phase C.
+
+**The @types pin (key to "no new tsc errors"):** we bump the three **runtime** to
+0.149 but keep **`@types/three@^0.141.0`** (unchanged from master). tsc only sees
+`@types/three`, so type-checking behaves exactly as it does today — no new errors,
+no `as any` churn — while the runtime gains the fixes. r149's runtime still ships
+all the deprecated aliases the 0.141 types describe (`PlaneBufferGeometry`,
+`Scene.autoUpdate`, `renderer.physicallyCorrectLights`, `BasisTextureLoader`), so
+the type/runtime skew is safe. Bumping `@types/three` to match the runtime is part
+of the Phase C migration. (`checkJs` is off, so the ~25 `.js` files that use the
+deprecated geometry names aren't type-checked anyway.)
+
+- `three` 0.141.0 → **0.149.0** (registry, integrity-locked); `@types/three`
+  **stays ^0.141.0**.
+- `patches/three+0.141.0.patch` → **`patches/three+0.149.0.patch`**, rebased by
+  3-way merge (base r141, ours = fork, theirs = r149). 20 hunks merged cleanly; 4
+  conflicts resolved behavior-preserving:
+  - `Object3D.js` (matrix-opt): took the fork side; also kept r149's new
+    `matrixWorldAutoUpdate` field so the renderer sees it.
+  - `WebGLRenderer.js` / `WebGLLights.js`: kept the reflection-probe additions
+    alongside r149's renamed light sort + clipping global-state call.
+  - `WebXRManager.js`: **dropped** — r149 upstreamed the fork's camera-matrix
+    `decompose`, so that patch is now obsolete.
+- The only genuine r149 runtime removal that affects us is `Object3D.DefaultUp` /
+  `DefaultMatrixAutoUpdate` → `DEFAULT_UP` / `DEFAULT_MATRIX_AUTO_UPDATE`; updated
+  the 3 (`.js`, untyped) call sites. The A-Frame fork does not use these.
+- `webpack.config.js`: transcoder paths repointed to `examples/jsm/libs` (moved
+  there by r149). `BasisTextureLoader` import stays stock (r149 still ships it).
+- `.browserslistrc`: Safari/iOS floor raised to **17**; Chrome to **91** (WebXR
+  baseline), XR device minimums inline. `.npmrc` / Dockerfile `--legacy-peer-deps`
+  for the intentional three-ahead-of-A-Frame peer mismatch.
+- A-Frame is left on `hubs/master` so the matrix-opt pairing (A-Frame sets
+  `matrixNeedsUpdate`, three's patch consumes it) stays intact.
+
+**Verification required (CI/runtime):** `npm run check` (tsc — expected green, since
+`@types/three` is unchanged) and `npm run build` (the Docker build runs this), plus
+a runtime smoke test on the target browsers and a VR/visionOS pass.
+The patch was verified to apply to a clean `three@0.150.0` and reproduce the merged
+sources exactly.
+
+## Phase B — retire the matrix-opt (stacks on A)
+
+Hypothesis (see security-analysis doc §1 discussion): modern three + JS engines no
+longer need the fork's custom matrix system, and `matrixWorldAutoUpdate` covers the
+static-scene case natively. This is the keystone removal — it also lets the A-Frame
+fork shed its `matrixNeedsUpdate` plumbing, moving it toward stock.
+
+- Gate on a benchmark: a scene with ~20-30 avatars + a heavy environment GLTF on
+  stock r150, comparing frame time with vs. without the matrix-opt (set
+  `o.matrixWorldAutoUpdate = false` on static roots).
+- Mechanical migration of the call sites once the benchmark clears:
+  - `grep -rE "matrixNeedsUpdate" src` → **68 files**: removable under stock
+    auto-update (or replace with explicit `updateMatrix()` where needed).
+  - `grep -rE "\.updateMatrices\(" src` → **43 files**: → `updateMatrixWorld()` /
+    `updateWorldMatrix(true, false)`.
+  - `grep -rE "\.near\(" src` (Vector3/Quaternion/Matrix4) → 3 files: → `.equals()`
+    or explicit epsilon.
+- Then drop the matrix-opt hunks from the three patch and the A-Frame
+  `matrixNeedsUpdate`/`updateMatrices` customizations.
+
+## Phase C — drop custom reflection probes + LUT tonemapping (next version jump)
+
+Both are Hubs-only three patches with no upstream equivalent. Replace with
+upstream-supported features at the jump past r152:
+
+- **Reflection probes** (`src/inflators/reflection-probe.ts`,
+  `src/bit-systems/scene-loading.ts`, `src/systems/environment-system.js`):
+  reimplement on light probes / baked env maps (or a post-processing approach).
+- **LUT tonemapping** (`src/systems/environment-system.js`, `src/effects.ts`):
+  move to a post-processing LUT pass.
+- Perform the **r152 color-management migration** here (the call-site inventory
+  below), which is the precondition for r152+ and A-Frame 1.5+.
+
+## Rework inventory (the "locations that need re-working")
+
+Seam files are annotated inline with `// UPGRADE`. The mechanical call-site sets are
+listed here rather than tagged in every file to avoid churn:
+
+| Concern | Phase | How to find every site |
+|---|---|---|
+| Custom matrix API | B | `grep -rE "matrixNeedsUpdate\|\.updateMatrices\(\|\.near\(" src` |
+| Color management | C / r152 | `grep -rE "sRGBEncoding\|LinearEncoding\|outputEncoding\|\.encoding\s*=" src` (17 files) |
+| Reflection probes | C | `src/inflators/reflection-probe.ts`, `src/systems/environment-system.js`, `src/bit-systems/scene-loading.ts` |
+| LUT tonemapping | C | `src/systems/environment-system.js`, `src/effects.ts` |
+| Raycaster layers shim | later | three patch (`Raycaster.js`): refactor interaction code to use layers, then drop |
+| Disabled WebGL2 morph path | B/C | three patch (`WebGLMorphtargets`/`WebGLProgram`): re-enable; relevant to high-blendshape VRM avatars |
+| Inlined three-vrm code | VRM | `src/utils/three-utils.js` (`excludeTriangles`/`createErasedMesh`): adopt `three-vrm` |
+
+## A-Frame — what r149 means for an A-Frame bump
+
+Short version: **Phase A (r149) needs no A-Frame change, and r149 does not move us
+any closer to a stock A-Frame.** Two things to keep separate:
+
+1. **The Hubs A-Frame fork on r149.** The fork (`hubs/master`) was built for three
+   r141 and runs unchanged on r149 — every API it relies on is still present
+   (r150 is where the removals land). It does not use the renamed `Object3D`
+   statics. So Phase A stays three-only; the `peer three@^0.141` mismatch is just a
+   warning we silence with `legacy-peer-deps`. That's the point of r149: keep the
+   fork as-is while the runtime moves forward.
+
+2. **Adopting upstream A-Frame is gated *past* r149.** Upstream A-Frame 1.4.x is
+   built for three **r150** (it uses `renderer.useLegacyLights`, an r150 API), and
+   1.5.x for ~r158. So you cannot bump to a stock A-Frame while pinning three at
+   r149 — doing so requires crossing the same r150 removal wall (the ~30-file
+   geometry/lighting/color migration). **An A-Frame bump and the r150 migration are
+   the same project**, which is why both live in Phase C, after Phase B removes the
+   matrix-opt coupling (the largest reason the fork can't track upstream).
+
+Sequencing, therefore:
+- **Phase A (now):** three r149, A-Frame fork unchanged.
+- **Phase B:** retire the matrix-opt — decouples the fork from the custom
+  `Object3D`, the prerequisite for tracking upstream A-Frame.
+- **Phase C:** cross r150 (the removal migration) + r152 (color management) and
+  move A-Frame to upstream 1.4/1.5 (or forward-port the fork) **together**, since
+  they're version-locked. `hubs/master-three-r147` is a useful reference (Hubs
+  already advanced the fork to r147 there), but it targets upstream three, so it
+  also assumes the matrix-opt is gone (Phase B).
+
+The fork itself diverged from upstream at ~v0.9 (Feb 2019) and is a hard fork, not
+a thin patch stack, so the Phase C A-Frame step is a forward-port/migration, not a
+patch-package stack.

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "sdp-transform": "^2.14.1",
         "semver": "^7.3.2",
         "stream-browserify": "^3.0.0",
-        "three": "^0.141.0",
+        "three": "^0.149.0",
         "three-ammo": "github:hubs-foundation/three-ammo",
         "three-gltf-extensions": "^0.0.14",
         "three-mesh-bvh": "^0.3.7",
@@ -3535,59 +3535,6 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
-    "node_modules/@mapbox/node-pre-gyp": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
-      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "make-dir": "^3.1.0",
-        "node-fetch": "^2.6.7",
-        "nopt": "^5.0.0",
-        "npmlog": "^5.0.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.11"
-      },
-      "bin": {
-        "node-pre-gyp": "bin/node-pre-gyp"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@mdx-js/react": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.0.tgz",
@@ -4890,27 +4837,6 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.7.0.tgz",
@@ -4994,14 +4920,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5369,6 +5287,7 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.141.0.tgz",
       "integrity": "sha512-OJdKDgTPVBUgc+s74DYoy4aLznbFFC38Xm4ElmU1YwGNgR7GGFVvFCX7lpVgOsT6S1zSJtGdajTsOYE8/xY9nA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/webxr": "*"
       }
@@ -5863,15 +5782,6 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -6116,32 +6026,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/aproba": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
-      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/argparse": {
@@ -7377,24 +7261,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/canvas": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
-      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.0",
-        "nan": "^2.17.0",
-        "simple-get": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/cardboard-vr-display": {
       "version": "1.0.19",
       "resolved": "https://registry.npmjs.org/cardboard-vr-display/-/cardboard-vr-display-1.0.19.tgz",
@@ -7883,18 +7749,6 @@
         "simple-swizzle": "^0.2.2"
       }
     },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
     "node_modules/colord": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
@@ -8054,15 +7908,6 @@
       "engines": {
         "node": ">=0.8"
       }
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -8788,21 +8633,6 @@
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true
     },
-    "node_modules/decompress-response": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "mimic-response": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -8990,15 +8820,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -9033,18 +8854,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-3.0.1.tgz",
       "integrity": "sha512-L6b76EfUxnoxGHM5Vz7nrshQPIbOHtitDWpGufrp5srQdJrEYi1xpUVZeFbfssWAJvUWo/iDIVlz8hOP4Z8OCw=="
-    },
-    "node_modules/detect-libc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/detect-node": {
       "version": "2.1.0",
@@ -9100,14 +8909,6 @@
       "resolved": "git+ssh://git@github.com/dmarcos/document-register-element.git#8ccc532b7f3744be954574caf3072a5fd260ca90",
       "integrity": "sha512-dwvGei9I/m1pYQ/9aNODyVmvSWBtlncfIROn5Sbi4MVnIcZKre5QaWx+AGLI/j6VH9sp8jwLyeuWP1micANT0g==",
       "license": "MIT"
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -11202,57 +11003,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gauge": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
-      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.2",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "signal-exit": "^3.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gauge/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gauge/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -11690,15 +11440,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -13737,17 +13478,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -14251,21 +13981,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -14487,15 +14202,6 @@
       "integrity": "sha512-Og/1AGzDp6b/9eYdgjn60HTQeIEKU8luLeYmLdsQDMTdhn385XH+IzcFy+zp9pmTHJt399KsIJ4MEtlNRLpOfw==",
       "dev": true
     },
-    "node_modules/nan": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
-      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -14658,24 +14364,6 @@
         "node": ">=12.19"
       }
     },
-    "node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -14753,22 +14441,6 @@
       },
       "bin": {
         "npm-scripts-info": "lib/cli.js"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "are-we-there-yet": "^2.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
-        "set-blocking": "^2.0.0"
       }
     },
     "node_modules/nth-check": {
@@ -15967,55 +15639,6 @@
         "lodash": "^4.17.20",
         "renderkid": "^3.0.0"
       }
-    },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/pretty-format/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/pretty-ms": {
       "version": "7.0.1",
@@ -17822,43 +17445,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/simple-get": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "decompress-response": "^4.2.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -19396,9 +18982,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.141.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.141.0.tgz",
-      "integrity": "sha512-JaSDAPWuk4RTzG5BYRQm8YZbERUxTfTDVouWgHMisS2to4E5fotMS9F2zPFNOIJyEFTTQDDKPpsgZVThKU3pXA==",
+      "version": "0.149.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.149.0.tgz",
+      "integrity": "sha512-tohpUxPDht0qExRLDTM8sjRLc5d9STURNrdnK3w9A+V4pxaTBfKWWT/IqtiLfg23Vfc3Z+ImNfvRw1/0CtxrkQ==",
       "license": "MIT"
     },
     "node_modules/three-ammo": {
@@ -19962,7 +19548,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21251,18 +20837,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "node_modules/wildcard": {

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "sdp-transform": "^2.14.1",
     "semver": "^7.3.2",
     "stream-browserify": "^3.0.0",
-    "three": "^0.141.0",
+    "three": "^0.149.0",
     "three-ammo": "github:hubs-foundation/three-ammo",
     "three-gltf-extensions": "^0.0.14",
     "three-mesh-bvh": "^0.3.7",

--- a/patches/three+0.149.0.patch
+++ b/patches/three+0.149.0.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/three/src/Three.js b/node_modules/three/src/Three.js
-index 605a974..5fdce4f 100644
+index 8254f9a..992c4e9 100644
 --- a/node_modules/three/src/Three.js
 +++ b/node_modules/three/src/Three.js
-@@ -65,6 +65,7 @@ export { AmbientLight } from './lights/AmbientLight.js';
+@@ -66,6 +66,7 @@ export { AmbientLight } from './lights/AmbientLight.js';
  export { AmbientLightProbe } from './lights/AmbientLightProbe.js';
  export { Light } from './lights/Light.js';
  export { LightProbe } from './lights/LightProbe.js';
@@ -11,7 +11,7 @@ index 605a974..5fdce4f 100644
  export { PerspectiveCamera } from './cameras/PerspectiveCamera.js';
  export { OrthographicCamera } from './cameras/OrthographicCamera.js';
 diff --git a/node_modules/three/src/animation/PropertyBinding.js b/node_modules/three/src/animation/PropertyBinding.js
-index 8e3b3d6..9e3abc7 100644
+index 9d23101..e9bb45c 100644
 --- a/node_modules/three/src/animation/PropertyBinding.js
 +++ b/node_modules/three/src/animation/PropertyBinding.js
 @@ -350,6 +350,7 @@ class PropertyBinding {
@@ -97,10 +97,10 @@ index 9c2a7a2..6771006 100644
  
  }
 diff --git a/node_modules/three/src/constants.js b/node_modules/three/src/constants.js
-index e2d666a..d1d6cd4 100644
+index a94efd7..72fe724 100644
 --- a/node_modules/three/src/constants.js
 +++ b/node_modules/three/src/constants.js
-@@ -53,6 +53,7 @@ export const ReinhardToneMapping = 2;
+@@ -52,6 +52,7 @@ export const ReinhardToneMapping = 2;
  export const CineonToneMapping = 3;
  export const ACESFilmicToneMapping = 4;
  export const CustomToneMapping = 5;
@@ -109,7 +109,7 @@ index e2d666a..d1d6cd4 100644
  export const UVMapping = 300;
  export const CubeReflectionMapping = 301;
 diff --git a/node_modules/three/src/core/Object3D.js b/node_modules/three/src/core/Object3D.js
-index ea06b54..61663d9 100644
+index 37c0cc2..050a8c2 100644
 --- a/node_modules/three/src/core/Object3D.js
 +++ b/node_modules/three/src/core/Object3D.js
 @@ -11,7 +11,9 @@ let _object3DId = 0;
@@ -137,8 +137,8 @@ index ea06b54..61663d9 100644
  class Object3D extends EventDispatcher {
  
  	constructor() {
-@@ -100,11 +110,18 @@ class Object3D extends EventDispatcher {
- 		this.matrixAutoUpdate = Object3D.DefaultMatrixAutoUpdate;
+@@ -100,6 +110,11 @@ class Object3D extends EventDispatcher {
+ 		this.matrixAutoUpdate = Object3D.DEFAULT_MATRIX_AUTO_UPDATE;
  		this.matrixWorldNeedsUpdate = false;
  
 +		// [HUBS] Special flags to avoid unnecessary matrices update
@@ -146,9 +146,10 @@ index ea06b54..61663d9 100644
 +		this.childrenNeedMatrixWorldUpdate = false;
 +		this.matrixIsModified = false;
 +		this.hasHadFirstMatrixUpdate = false;
-+
+ 		this.matrixWorldAutoUpdate = Object3D.DEFAULT_MATRIX_WORLD_AUTO_UPDATE; // checked by the renderer
+ 
  		this.layers = new Layers();
- 		this.visible = true;
+@@ -107,6 +122,7 @@ class Object3D extends EventDispatcher {
  
  		this.castShadow = false;
  		this.receiveShadow = false;
@@ -156,7 +157,7 @@ index ea06b54..61663d9 100644
  
  		this.frustumCulled = true;
  		this.renderOrder = 0;
-@@ -127,6 +144,8 @@ class Object3D extends EventDispatcher {
+@@ -129,6 +145,8 @@ class Object3D extends EventDispatcher {
  
  		this.matrix.decompose( this.position, this.quaternion, this.scale );
  
@@ -165,7 +166,7 @@ index ea06b54..61663d9 100644
  	}
  
  	applyQuaternion( q ) {
-@@ -285,6 +304,8 @@ class Object3D extends EventDispatcher {
+@@ -291,6 +309,8 @@ class Object3D extends EventDispatcher {
  
  		}
  
@@ -174,7 +175,7 @@ index ea06b54..61663d9 100644
  		this.quaternion.setFromRotationMatrix( _m1 );
  
  		if ( parent ) {
-@@ -295,6 +316,16 @@ class Object3D extends EventDispatcher {
+@@ -301,6 +321,16 @@ class Object3D extends EventDispatcher {
  
  		}
  
@@ -191,7 +192,7 @@ index ea06b54..61663d9 100644
  	}
  
  	add( object ) {
-@@ -328,6 +359,7 @@ class Object3D extends EventDispatcher {
+@@ -334,6 +364,7 @@ class Object3D extends EventDispatcher {
  
  			object.parent = this;
  			this.children.push( object );
@@ -199,7 +200,7 @@ index ea06b54..61663d9 100644
  
  			object.dispatchEvent( _addedEvent );
  
-@@ -362,6 +394,13 @@ class Object3D extends EventDispatcher {
+@@ -368,6 +399,13 @@ class Object3D extends EventDispatcher {
  			object.parent = null;
  			this.children.splice( index, 1 );
  
@@ -213,21 +214,15 @@ index ea06b54..61663d9 100644
  			object.dispatchEvent( _removedEvent );
  
  		}
-@@ -554,76 +593,161 @@ class Object3D extends EventDispatcher {
+@@ -582,88 +620,161 @@ class Object3D extends EventDispatcher {
  
  		this.matrixWorldNeedsUpdate = true;
  
--	}
--
--	updateMatrixWorld( force ) {
--
--		if ( this.matrixAutoUpdate ) this.updateMatrix();
 +		this._handleMatrixModification( this );
++
+ 	}
  
--		if ( this.matrixWorldNeedsUpdate || force ) {
-+	}
- 
--			if ( this.parent === null ) {
+-	updateMatrixWorld( force ) {
 +	// [HUBS] Computes this object's matrices and then the recursively computes the matrices of all the children.
 +	//
 +	// forceWorldUpdate - If true and the object is visible, will force the world matrix to be updated for
@@ -236,70 +231,73 @@ index ea06b54..61663d9 100644
 +	// includeInvisible - If true, does not ignore non-visible objects.
 +	updateMatrixWorld( forceWorldUpdate, includeInvisible ) {
  
--				this.matrixWorld.copy( this.matrix );
+-		if ( this.matrixAutoUpdate ) this.updateMatrix();
 +		if ( ! this.visible && ! includeInvisible ) {
  
--			} else {
+-		if ( this.matrixWorldNeedsUpdate || force ) {
 +			if ( forceWorldUpdate ) {
  
--				this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
+-			if ( this.parent === null ) {
 +				this.matrixWorldNeedsUpdate = true;
  
- 			}
+-				this.matrixWorld.copy( this.matrix );
++			}
  
--			this.matrixWorldNeedsUpdate = false;
--
--			force = true;
+-			} else {
 +			return;
  
- 		}
+-				this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
++		}
  
--		// update children
+-			}
 +		// Do not recurse upwards, since this is recursing downwards
 +		this.updateMatrices( false, forceWorldUpdate, true );
  
- 		const children = this.children;
+-			this.matrixWorldNeedsUpdate = false;
++		const children = this.children;
 +		const forceChildrenWorldUpdate = this.childrenNeedMatrixWorldUpdate || forceWorldUpdate;
++
++		for ( let i = 0, l = children.length; i < l; i ++ ) {
  
- 		for ( let i = 0, l = children.length; i < l; i ++ ) {
- 
--			children[ i ].updateMatrixWorld( force );
+-			force = true;
 +			children[ i ].updateMatrixWorld( forceChildrenWorldUpdate, includeInvisible );
  
  		}
  
+-		// update children
 +		this.childrenNeedMatrixWorldUpdate = false;
-+
- 	}
  
-+
+-		const children = this.children;
++	}
+ 
+-		for ( let i = 0, l = children.length; i < l; i ++ ) {
+ 
+-			const child = children[ i ];
 +	// [HUBS] Updates this function to use updateMatrices(). In general our code should prefer calling updateMatrices() directly,
 +	// patching this for compatibility upstream, namely with Box3.expandToObject and Object3D.attach
- 	updateWorldMatrix( updateParents, updateChildren ) {
- 
--		const parent = this.parent;
++	updateWorldMatrix( updateParents, updateChildren ) {
++
 +		this.updateMatrices( false, false, ! updateParents );
  
--		if ( updateParents === true && parent !== null ) {
+-			if ( child.matrixWorldAutoUpdate === true || force === true ) {
 +		if ( updateChildren ) {
- 
--			parent.updateWorldMatrix( true, false );
++
 +			const children = this.children;
 +
 +			for ( let i = 0, l = children.length; i < l; i ++ ) {
-+
-+				children[ i ].updateMatrixWorld( false, false );
-+
-+			}
-+
-+			this.childrenNeedMatrixWorldUpdate = false;
  
+-				child.updateMatrixWorld( force );
++				children[ i ].updateMatrixWorld( false, false );
+ 
+ 			}
+ 
++			this.childrenNeedMatrixWorldUpdate = false;
++
  		}
  
--		if ( this.matrixAutoUpdate ) this.updateMatrix();
-+	}
+ 	}
  
--		if ( this.parent === null ) {
+-	updateWorldMatrix( updateParents, updateChildren ) {
 +	// [HUBS] By the end of this function this.matrix reflects the updated local matrix
 +	// and this.matrixWorld reflects the updated world matrix, taking into account
 +	// parent matrices.
@@ -329,44 +327,51 @@ index ea06b54..61663d9 100644
 +				// identity matrix is updated.
 +				this.updateMatrix();
  
--			this.matrixWorld.copy( this.matrix );
+-		const parent = this.parent;
 +			}
  
--		} else {
+-		if ( updateParents === true && parent !== null && parent.matrixWorldAutoUpdate === true ) {
 +			this.hasHadFirstMatrixUpdate = true;
 +			this.matrixWorldNeedsUpdate = true;
 +			this.cachedMatrixWorld = this.matrixWorld;
-+
+ 
+-			parent.updateWorldMatrix( true, false );
 +		} else if ( this.matrixNeedsUpdate || this.matrixAutoUpdate || forceLocalUpdate ) {
  
--			this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
+-		}
 +			// updateMatrix() sets matrixWorldNeedsUpdate = true
 +			this.updateMatrix();
 +			this.matrixNeedsUpdate = false;
  
- 		}
+-		if ( this.matrixAutoUpdate ) this.updateMatrix();
++		}
  
--		// update children
+-		if ( this.parent === null ) {
 +		if ( ! skipParents && this.parent ) {
  
--		if ( updateChildren === true ) {
+-			this.matrixWorld.copy( this.matrix );
 +			this.parent.updateMatrices( false, forceWorldUpdate, false );
 +			this.matrixWorldNeedsUpdate = this.matrixWorldNeedsUpdate || this.parent.childrenNeedMatrixWorldUpdate;
  
--			const children = this.children;
+-		} else {
 +		}
  
--			for ( let i = 0, l = children.length; i < l; i ++ ) {
+-			this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
 +		if ( this.matrixWorldNeedsUpdate || forceWorldUpdate ) {
-+
+ 
+-		}
 +			_m2.copy( this.matrixWorld );
-+
+ 
+-		// update children
 +			if ( this.parent === null ) {
-+
+ 
+-		if ( updateChildren === true ) {
 +				this.matrixWorld.copy( this.matrix );
-+
+ 
+-			const children = this.children;
 +			} else {
-+
+ 
+-			for ( let i = 0, l = children.length; i < l; i ++ ) {
 +				// If the matrix is unmodified, it is the identity matrix,
 +				// and hence we can use the parent's world matrix directly.
 +				//
@@ -374,20 +379,22 @@ index ea06b54..61663d9 100644
 +				// *or* will update the parent themselves beforehand as is done in
 +				// updateMatrixWorld.
 +				if ( ! this.matrixIsModified ) {
-+
+ 
+-				const child = children[ i ];
 +					this.matrixWorld = this.parent.matrixWorld;
-+
+ 
+-				if ( child.matrixWorldAutoUpdate === true ) {
 +				} else {
-+
+ 
+-					child.updateWorldMatrix( false, true );
 +					// Once matrixIsModified === true, this.matrixWorld has been updated to be a local
 +					// copy, not a reference to this.parent.matrixWorld (see updateMatrix/applyMatrix)
 +					this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
-+
-+				}
  
--				children[ i ].updateWorldMatrix( false, true );
-+			}
-+
+ 				}
+ 
+ 			}
+ 
 +			if ( _m2.near( this.matrixWorld, _epsilon ) ) {
 +
 +				this.matrixWorld.copy( _m2 );
@@ -395,15 +402,15 @@ index ea06b54..61663d9 100644
 +			} else {
 +
 +				this.childrenNeedMatrixWorldUpdate = true;
- 
- 			}
- 
++
++			}
++
 +			this.matrixWorldNeedsUpdate = false;
 +
  		}
  
  	}
-@@ -919,6 +1043,23 @@ class Object3D extends EventDispatcher {
+@@ -961,6 +1072,23 @@ class Object3D extends EventDispatcher {
  
  	}
  
@@ -426,7 +433,7 @@ index ea06b54..61663d9 100644
 +
  }
  
- Object3D.DefaultUp = new Vector3( 0, 1, 0 );
+ Object3D.DEFAULT_UP = /*@__PURE__*/ new Vector3( 0, 1, 0 );
 diff --git a/node_modules/three/src/core/Raycaster.js b/node_modules/three/src/core/Raycaster.js
 index c4f0c37..86a8f29 100644
 --- a/node_modules/three/src/core/Raycaster.js
@@ -444,19 +451,6 @@ index c4f0c37..86a8f29 100644
 +	object.raycast( raycaster, intersects );
  
  	if ( recursive === true ) {
- 
-diff --git a/node_modules/three/src/extras/PMREMGenerator.js b/node_modules/three/src/extras/PMREMGenerator.js
-index 9e752b9..d87d192 100644
---- a/node_modules/three/src/extras/PMREMGenerator.js
-+++ b/node_modules/three/src/extras/PMREMGenerator.js
-@@ -261,7 +261,7 @@ class PMREMGenerator {
- 
- 		const cubeUVRenderTarget = _createRenderTarget( width, height, params );
- 
--		if ( this._pingPongRenderTarget === null || this._pingPongRenderTarget.width !== width ) {
-+		if ( this._pingPongRenderTarget === null || this._pingPongRenderTarget.width !== width || this._pingPongRenderTarget.height !== height ) {
- 
- 			if ( this._pingPongRenderTarget !== null ) {
  
 diff --git a/node_modules/three/src/lights/ReflectionProbe.js b/node_modules/three/src/lights/ReflectionProbe.js
 new file mode 100644
@@ -497,28 +491,10 @@ index 0000000..6f31da3
 +
 +export { ReflectionProbe };
 diff --git a/node_modules/three/src/loaders/FileLoader.js b/node_modules/three/src/loaders/FileLoader.js
-index d9a9618..ac5dc08 100644
+index 1e528eb..5b4060d 100644
 --- a/node_modules/three/src/loaders/FileLoader.js
 +++ b/node_modules/three/src/loaders/FileLoader.js
-@@ -3,6 +3,17 @@ import { Loader } from './Loader.js';
- 
- const loading = {};
- 
-+class HttpError extends Error {
-+
-+	constructor( message, response ) {
-+
-+		super( message );
-+		this.response = response;
-+
-+	}
-+
-+}
-+
- class FileLoader extends Loader {
- 
- 	constructor( manager ) {
-@@ -19,7 +30,10 @@ class FileLoader extends Loader {
+@@ -30,7 +30,10 @@ class FileLoader extends Loader {
  
  		url = this.manager.resolveURL( url );
  
@@ -530,7 +506,7 @@ index d9a9618..ac5dc08 100644
  
  		if ( cached !== undefined ) {
  
-@@ -39,9 +53,9 @@ class FileLoader extends Loader {
+@@ -50,9 +53,9 @@ class FileLoader extends Loader {
  
  		// Check if request is duplicate
  
@@ -542,7 +518,7 @@ index d9a9618..ac5dc08 100644
  
  				onLoad: onLoad,
  				onProgress: onProgress,
-@@ -54,9 +68,9 @@ class FileLoader extends Loader {
+@@ -65,9 +68,9 @@ class FileLoader extends Loader {
  		}
  
  		// Initialise array for duplicate requests
@@ -554,7 +530,7 @@ index d9a9618..ac5dc08 100644
  			onLoad: onLoad,
  			onProgress: onProgress,
  			onError: onError,
-@@ -77,7 +91,7 @@ class FileLoader extends Loader {
+@@ -88,7 +91,7 @@ class FileLoader extends Loader {
  		fetch( req )
  			.then( response => {
  
@@ -563,7 +539,7 @@ index d9a9618..ac5dc08 100644
  
  					// Some browsers return HTTP Status 0 when using non-http protocol
  					// e.g. 'file://' or 'data://'. Handle as success.
-@@ -88,6 +102,12 @@ class FileLoader extends Loader {
+@@ -99,6 +102,12 @@ class FileLoader extends Loader {
  
  					}
  
@@ -576,16 +552,16 @@ index d9a9618..ac5dc08 100644
  					// Workaround: Checking if response.body === undefined for Alipay browser #23548
  
  					if ( typeof ReadableStream === 'undefined' || response.body === undefined || response.body.getReader === undefined ) {
-@@ -96,7 +116,7 @@ class FileLoader extends Loader {
+@@ -107,7 +116,7 @@ class FileLoader extends Loader {
  
  					}
  
 -					const callbacks = loading[ url ];
 +					const callbacks = loading[ key ];
  					const reader = response.body.getReader();
- 					const contentLength = response.headers.get( 'Content-Length' );
- 					const total = contentLength ? parseInt( contentLength ) : 0;
-@@ -201,10 +221,10 @@ class FileLoader extends Loader {
+ 
+ 					// Nginx needs X-File-Size check
+@@ -215,10 +224,10 @@ class FileLoader extends Loader {
  
  				// Add to cache only on HTTP success, so that we do not cache
  				// error response bodies as proper responses to requests.
@@ -599,7 +575,7 @@ index d9a9618..ac5dc08 100644
  
  				for ( let i = 0, il = callbacks.length; i < il; i ++ ) {
  
-@@ -218,7 +238,7 @@ class FileLoader extends Loader {
+@@ -232,7 +241,7 @@ class FileLoader extends Loader {
  
  				// Abort errors and other errors are handled the same
  
@@ -608,7 +584,7 @@ index d9a9618..ac5dc08 100644
  
  				if ( callbacks === undefined ) {
  
-@@ -228,7 +248,7 @@ class FileLoader extends Loader {
+@@ -242,7 +251,7 @@ class FileLoader extends Loader {
  
  				}
  
@@ -618,10 +594,10 @@ index d9a9618..ac5dc08 100644
  				for ( let i = 0, il = callbacks.length; i < il; i ++ ) {
  
 diff --git a/node_modules/three/src/math/Matrix4.js b/node_modules/three/src/math/Matrix4.js
-index 2c327f3..44eed15 100644
+index 9b12867..7799f03 100644
 --- a/node_modules/three/src/math/Matrix4.js
 +++ b/node_modules/three/src/math/Matrix4.js
-@@ -831,6 +831,22 @@ class Matrix4 {
+@@ -807,6 +807,22 @@ class Matrix4 {
  
  	}
  
@@ -645,10 +621,10 @@ index 2c327f3..44eed15 100644
  
  		for ( let i = 0; i < 16; i ++ ) {
 diff --git a/node_modules/three/src/math/Quaternion.js b/node_modules/three/src/math/Quaternion.js
-index 6f38435..aaf4bd1 100644
+index 3d67435..7f9e4b8 100644
 --- a/node_modules/three/src/math/Quaternion.js
 +++ b/node_modules/three/src/math/Quaternion.js
-@@ -639,6 +639,16 @@ class Quaternion {
+@@ -619,6 +619,16 @@ class Quaternion {
  
  	}
  
@@ -666,10 +642,10 @@ index 6f38435..aaf4bd1 100644
  
  		this._x = array[ offset ];
 diff --git a/node_modules/three/src/math/Vector3.js b/node_modules/three/src/math/Vector3.js
-index 8ab4574..b8249e1 100644
+index 7b18ab3..fd1073c 100644
 --- a/node_modules/three/src/math/Vector3.js
 +++ b/node_modules/three/src/math/Vector3.js
-@@ -676,6 +676,15 @@ class Vector3 {
+@@ -643,6 +643,15 @@ class Vector3 {
  
  	}
  
@@ -686,7 +662,7 @@ index 8ab4574..b8249e1 100644
  
  		this.x = array[ offset ];
 diff --git a/node_modules/three/src/renderers/WebGLCubeRenderTarget.js b/node_modules/three/src/renderers/WebGLCubeRenderTarget.js
-index a5a7ddd..800a13a 100644
+index 3f22ea3..f8f07d7 100644
 --- a/node_modules/three/src/renderers/WebGLCubeRenderTarget.js
 +++ b/node_modules/three/src/renderers/WebGLCubeRenderTarget.js
 @@ -83,6 +83,7 @@ class WebGLCubeRenderTarget extends WebGLRenderTarget {
@@ -698,7 +674,7 @@ index a5a7ddd..800a13a 100644
  					gl_FragColor = texture2D( tEquirect, sampleUV );
  
 diff --git a/node_modules/three/src/renderers/WebGLRenderer.js b/node_modules/three/src/renderers/WebGLRenderer.js
-index 4669da7..dd2836d 100644
+index 5163705..401ed37 100644
 --- a/node_modules/three/src/renderers/WebGLRenderer.js
 +++ b/node_modules/three/src/renderers/WebGLRenderer.js
 @@ -17,6 +17,7 @@ import { Matrix4 } from '../math/Matrix4.js';
@@ -709,7 +685,7 @@ index 4669da7..dd2836d 100644
  import { WebGLAnimation } from './webgl/WebGLAnimation.js';
  import { WebGLAttributes } from './webgl/WebGLAttributes.js';
  import { WebGLBackground } from './webgl/WebGLBackground.js';
-@@ -54,6 +55,16 @@ function createCanvasElement() {
+@@ -55,6 +56,16 @@ function createCanvasElement() {
  
  }
  
@@ -726,7 +702,7 @@ index 4669da7..dd2836d 100644
  function WebGLRenderer( parameters = {} ) {
  
  	this.isWebGLRenderer = true;
-@@ -207,6 +218,9 @@ function WebGLRenderer( parameters = {} ) {
+@@ -186,6 +197,9 @@ function WebGLRenderer( parameters = {} ) {
  	const _vector2 = new Vector2();
  	const _vector3 = new Vector3();
  
@@ -736,7 +712,7 @@ index 4669da7..dd2836d 100644
  	const _emptyScene = { background: null, fog: null, environment: null, overrideMaterial: null, isScene: true };
  
  	function getTargetPixelRatio() {
-@@ -1207,6 +1221,14 @@ function WebGLRenderer( parameters = {} ) {
+@@ -1211,6 +1225,13 @@ function WebGLRenderer( parameters = {} ) {
  
  		currentRenderState.setupLightsView( camera );
  
@@ -747,11 +723,10 @@ index 4669da7..dd2836d 100644
 +			cubeuvmaps.get( reflectionProbes[ i ].texture );
 +
 +		}
-+
- 		if ( transmissiveObjects.length > 0 ) renderTransmissionPass( opaqueObjects, scene, camera );
+ 		if ( _clippingEnabled === true ) clipping.setGlobalState( _this.clippingPlanes, camera );
  
- 		if ( viewport ) state.viewport( _currentViewport.copy( viewport ) );
-@@ -1715,6 +1737,90 @@ function WebGLRenderer( parameters = {} ) {
+ 		if ( transmissiveObjects.length > 0 ) renderTransmissionPass( opaqueObjects, scene, camera );
+@@ -1722,6 +1743,90 @@ function WebGLRenderer( parameters = {} ) {
  
  		}
  
@@ -842,7 +817,7 @@ index 4669da7..dd2836d 100644
  		const morphAttributes = geometry.morphAttributes;
  
  		if ( morphAttributes.position !== undefined || morphAttributes.normal !== undefined || ( morphAttributes.color !== undefined && capabilities.isWebGL2 === true ) ) {
-@@ -1734,6 +1840,7 @@ function WebGLRenderer( parameters = {} ) {
+@@ -1750,6 +1855,7 @@ function WebGLRenderer( parameters = {} ) {
  		if ( refreshMaterial ) {
  
  			p_uniforms.setValue( _gl, 'toneMappingExposure', _this.toneMappingExposure );
@@ -942,12 +917,12 @@ index 5087a83..ba833db 100644
  vec3 CustomToneMapping( vec3 color ) { return color; }
  `;
 diff --git a/node_modules/three/src/renderers/shaders/ShaderLib.js b/node_modules/three/src/renderers/shaders/ShaderLib.js
-index 126df13..9e19b5f 100644
+index 3e628c0..a544f34 100644
 --- a/node_modules/three/src/renderers/shaders/ShaderLib.js
 +++ b/node_modules/three/src/renderers/shaders/ShaderLib.js
-@@ -75,7 +75,13 @@ const ShaderLib = {
+@@ -78,7 +78,13 @@ const ShaderLib = {
  
- 		uniforms: mergeUniforms( [
+ 		uniforms: /*@__PURE__*/ mergeUniforms( [
  			UniformsLib.common,
 -			UniformsLib.envmap,
 +			( () => {
@@ -961,10 +936,10 @@ index 126df13..9e19b5f 100644
  			UniformsLib.lightmap,
  			UniformsLib.emissivemap,
 diff --git a/node_modules/three/src/renderers/webgl/WebGLLights.js b/node_modules/three/src/renderers/webgl/WebGLLights.js
-index 7e7f0ce..0857430 100644
+index 2f0df97..2decc09 100644
 --- a/node_modules/three/src/renderers/webgl/WebGLLights.js
 +++ b/node_modules/three/src/renderers/webgl/WebGLLights.js
-@@ -174,6 +174,7 @@ function WebGLLights( extensions, capabilities ) {
+@@ -175,6 +175,7 @@ function WebGLLights( extensions, capabilities ) {
  
  		ambient: [ 0, 0, 0 ],
  		probe: [],
@@ -972,16 +947,16 @@ index 7e7f0ce..0857430 100644
  		directional: [],
  		directionalShadow: [],
  		directionalShadowMap: [],
-@@ -215,6 +216,8 @@ function WebGLLights( extensions, capabilities ) {
- 		let numPointShadows = 0;
- 		let numSpotShadows = 0;
+@@ -220,6 +221,8 @@ function WebGLLights( extensions, capabilities ) {
+ 		let numSpotMaps = 0;
+ 		let numSpotShadowsWithMaps = 0;
  
 +		let numReflectionProbes = 0;
 +
- 		lights.sort( shadowCastingLightsFirst );
+ 		// ordering : [shadow casting + map texturing, map texturing, shadow casting, none ]
+ 		lights.sort( shadowCastingAndTexturingLightsFirst );
  
- 		// artist-friendly light intensity scaling factor
-@@ -244,6 +247,10 @@ function WebGLLights( extensions, capabilities ) {
+@@ -250,6 +253,10 @@ function WebGLLights( extensions, capabilities ) {
  
  				}
  
@@ -992,7 +967,7 @@ index 7e7f0ce..0857430 100644
  			} else if ( light.isDirectionalLight ) {
  
  				const uniforms = cache.get( light );
-@@ -411,6 +418,8 @@ function WebGLLights( extensions, capabilities ) {
+@@ -427,6 +434,8 @@ function WebGLLights( extensions, capabilities ) {
  		state.ambient[ 1 ] = g;
  		state.ambient[ 2 ] = b;
  
@@ -1002,10 +977,10 @@ index 7e7f0ce..0857430 100644
  
  		if ( hash.directionalLength !== directionalLength ||
 diff --git a/node_modules/three/src/renderers/webgl/WebGLMaterials.js b/node_modules/three/src/renderers/webgl/WebGLMaterials.js
-index 188aa81..24d0d4f 100644
+index 2f249bb..d42728c 100644
 --- a/node_modules/three/src/renderers/webgl/WebGLMaterials.js
 +++ b/node_modules/three/src/renderers/webgl/WebGLMaterials.js
-@@ -173,7 +173,12 @@ function WebGLMaterials( renderer, properties ) {
+@@ -174,7 +174,12 @@ function WebGLMaterials( renderer, properties ) {
  
  		if ( envMap ) {
  
@@ -1020,10 +995,10 @@ index 188aa81..24d0d4f 100644
  			uniforms.flipEnvMap.value = ( envMap.isCubeTexture && envMap.isRenderTargetTexture === false ) ? - 1 : 1;
  
 diff --git a/node_modules/three/src/renderers/webgl/WebGLMorphtargets.js b/node_modules/three/src/renderers/webgl/WebGLMorphtargets.js
-index b8d5fe6..f43bb48 100644
+index 4fb585a..73cd578 100644
 --- a/node_modules/three/src/renderers/webgl/WebGLMorphtargets.js
 +++ b/node_modules/three/src/renderers/webgl/WebGLMorphtargets.js
-@@ -48,7 +48,7 @@ function WebGLMorphtargets( gl, capabilities, textures ) {
+@@ -34,7 +34,7 @@ function WebGLMorphtargets( gl, capabilities, textures ) {
  
  		const objectInfluences = object.morphTargetInfluences;
  
@@ -1033,7 +1008,7 @@ index b8d5fe6..f43bb48 100644
  			// instead of using attributes, the WebGL 2 code path encodes morph targets
  			// into an array of data textures. Each layer represents a single morph target.
 diff --git a/node_modules/three/src/renderers/webgl/WebGLProgram.js b/node_modules/three/src/renderers/webgl/WebGLProgram.js
-index 5e9ee69..80b13ed 100644
+index 99fc10e..c300a1e 100644
 --- a/node_modules/three/src/renderers/webgl/WebGLProgram.js
 +++ b/node_modules/three/src/renderers/webgl/WebGLProgram.js
 @@ -1,7 +1,7 @@
@@ -1056,7 +1031,7 @@ index 5e9ee69..80b13ed 100644
  		default:
  			console.warn( 'THREE.WebGLProgram: Unsupported toneMapping:', toneMapping );
  			toneMappingName = 'Linear';
-@@ -511,10 +515,13 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
+@@ -506,10 +510,13 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
  
  			parameters.morphTargets ? '#define USE_MORPHTARGETS' : '',
  			parameters.morphNormals && parameters.flatShading === false ? '#define USE_MORPHNORMALS' : '',
@@ -1074,7 +1049,7 @@ index 5e9ee69..80b13ed 100644
  			parameters.doubleSided ? '#define DOUBLE_SIDED' : '',
  			parameters.flipSided ? '#define FLIP_SIDED' : '',
  
-@@ -688,6 +695,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
+@@ -683,6 +690,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
  			'uniform bool isOrthographic;',
  
  			( parameters.toneMapping !== NoToneMapping ) ? '#define TONE_MAPPING' : '',
@@ -1083,10 +1058,10 @@ index 5e9ee69..80b13ed 100644
  			( parameters.toneMapping !== NoToneMapping ) ? getToneMappingFunction( 'toneMapping', parameters.toneMapping ) : '',
  
 diff --git a/node_modules/three/src/renderers/webgl/WebGLState.js b/node_modules/three/src/renderers/webgl/WebGLState.js
-index dff3fb2..85fd4c6 100644
+index e5d08fa..390a490 100644
 --- a/node_modules/three/src/renderers/webgl/WebGLState.js
 +++ b/node_modules/three/src/renderers/webgl/WebGLState.js
-@@ -928,11 +928,27 @@ function WebGLState( gl, extensions, capabilities ) {
+@@ -938,11 +938,27 @@ function WebGLState( gl, extensions, capabilities ) {
  
  	}
  
@@ -1116,7 +1091,7 @@ index dff3fb2..85fd4c6 100644
  
  		} catch ( error ) {
  
-@@ -1012,11 +1028,19 @@ function WebGLState( gl, extensions, capabilities ) {
+@@ -1050,11 +1066,19 @@ function WebGLState( gl, extensions, capabilities ) {
  
  	}
  
@@ -1138,7 +1113,7 @@ index dff3fb2..85fd4c6 100644
  
  		} catch ( error ) {
  
-@@ -1026,11 +1050,19 @@ function WebGLState( gl, extensions, capabilities ) {
+@@ -1064,11 +1088,19 @@ function WebGLState( gl, extensions, capabilities ) {
  
  	}
  
@@ -1160,16 +1135,3 @@ index dff3fb2..85fd4c6 100644
  
  		} catch ( error ) {
  
-diff --git a/node_modules/three/src/renderers/webxr/WebXRManager.js b/node_modules/three/src/renderers/webxr/WebXRManager.js
-index 308be47..3539221 100644
---- a/node_modules/three/src/renderers/webxr/WebXRManager.js
-+++ b/node_modules/three/src/renderers/webxr/WebXRManager.js
-@@ -506,6 +506,8 @@ class WebXRManager extends EventDispatcher {
- 			camera.quaternion.copy( cameraVR.quaternion );
- 			camera.scale.copy( cameraVR.scale );
- 			camera.matrix.copy( cameraVR.matrix );
-+			camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
-+
- 			camera.matrixWorld.copy( cameraVR.matrixWorld );
- 
- 			const children = camera.children;

--- a/src/components/emoji-hud.js
+++ b/src/components/emoji-hud.js
@@ -143,9 +143,9 @@ AFRAME.registerComponent("emoji-hud", {
       cameraForward.transformDirection(cameraObject3D.matrixWorld);
       projectedCameraForward.set(0, 0, -1);
       projectedCameraForward.transformDirection(cameraObject3D.matrixWorld);
-      projectedCameraForward.projectOnPlane(THREE.Object3D.DefaultUp).normalize();
+      projectedCameraForward.projectOnPlane(THREE.Object3D.DEFAULT_UP).normalize();
       const angle =
-        Math.sign(THREE.Object3D.DefaultUp.dot(cameraForward)) * projectedCameraForward.angleTo(cameraForward);
+        Math.sign(THREE.Object3D.DEFAULT_UP.dot(cameraForward)) * projectedCameraForward.angleTo(cameraForward);
       const angleOffset = angle - Math.max(this.data.minHudAngle, Math.min(this.data.maxHudAngle, angle));
       angledCameraForward.set(0, 0, -1);
       angledCameraForward.applyAxisAngle(defaultRight, this.data.hudAngle - angleOffset);

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -513,7 +513,7 @@ class GLTFHubsPlugin {
     gltf.scene.traverse(object => {
       // GLTFLoader sets matrixAutoUpdate on animated objects, we want to keep the defaults
       // @TODO: Should this be fixed in the gltf loader?
-      object.matrixAutoUpdate = THREE.Object3D.DefaultMatrixAutoUpdate;
+      object.matrixAutoUpdate = THREE.Object3D.DEFAULT_MATRIX_AUTO_UPDATE;
       convertStandardMaterialsIfNeeded(object);
     });
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -33,7 +33,7 @@ import "./utils/aframe-overrides";
 // So we disable it here.
 import * as THREE from "three";
 THREE.Cache.enabled = false;
-THREE.Object3D.DefaultMatrixAutoUpdate = false;
+THREE.Object3D.DEFAULT_MATRIX_AUTO_UPDATE = false;
 
 import "./utils/logging";
 import { patchWebGLRenderingContext } from "./utils/webgl";

--- a/src/inflators/reflection-probe.ts
+++ b/src/inflators/reflection-probe.ts
@@ -21,7 +21,11 @@ export function inflateReflectionProbe(world: HubsWorld, eid: number, componentP
   const box = new THREE.Box3().setFromCenterAndSize(new THREE.Vector3(), new THREE.Vector3().setScalar(size * 2));
 
   addComponent(world, ReflectionProbe, eid);
-  // TODO: Add ReflectionProbe to three.js type defs
+  // UPGRADE [Option C]: THREE.ReflectionProbe is a Hubs-only addition carried in
+  // patches/three+0.150.0.patch (box-projected env-map blending in WebGLRenderer). It has no
+  // upstream equivalent, so it must be reimplemented on stock primitives (light probes / baked
+  // env maps) before this patch can be dropped. The `as any` cast exists because the type isn't
+  // in @types/three. See doc/renderer-rebase-plan.md.
   const probe = new (THREE as any).ReflectionProbe(box, envMapTexture);
   addObject3DComponent(world, eid, probe);
 

--- a/src/systems/environment-system.js
+++ b/src/systems/environment-system.js
@@ -5,6 +5,17 @@ import { LUTCubeLoader } from "three/examples/jsm/loaders/LUTCubeLoader";
 import blenderLutPath from "../assets/blender-lut.cube";
 import { NoToneMapping } from "three";
 
+// UPGRADE: this file is the central seam for the three.js renderer-feature rework. See
+// doc/renderer-rebase-plan.md for the full inventory. Three things gate moving past r150:
+//   1. [r152 color management] `outputEncoding`/`sRGBEncoding`/`LinearEncoding` and per-texture
+//      `.encoding` are removed in r152 (replaced by `outputColorSpace`/`colorSpace` +
+//      `SRGBColorSpace`/`NoColorSpace`, with `ColorManagement.enabled` on by default). All such
+//      call sites (run `grep -rE "sRGBEncoding|LinearEncoding|outputEncoding|\.encoding" src`)
+//      must migrate together, and scene appearance re-validated.
+//   2. [Option C] `LUTToneMapping` is a Hubs-only three patch. Replace with an upstream-supported
+//      path (post-processing LUT pass, or upstream tone-mapping) when jumping past the patch.
+//   3. [Option C] Reflection probes are a Hubs-only three patch (box-projected env maps). Replace
+//      with an upstream equivalent (light probes / baked env maps) at the next version jump.
 const toneMappingOptions = {
   None: "NoToneMapping",
   Linear: "LinearToneMapping",

--- a/src/utils/three-utils.js
+++ b/src/utils/three-utils.js
@@ -371,6 +371,11 @@ import { MediaVideo } from "../bit-components";
 import { Text } from "troika-three-text";
 
 // This code is from three-vrm. We will likely be using that in the future and this inlined code can go away
+// UPGRADE [VRM]: VRM avatars are loaded by the stock GLTFLoader (no `three-vrm` dependency) and then
+// post-processed here by indexing bone-weight / skin-index arrays directly. Malformed VRM skin data
+// can index out of bounds here (a suspected source of the avatar-injection crash). Adopting the real
+// `three-vrm` package (which validates VRM) + a newer GLTFLoader is the durable fix. See
+// doc/renderer-rebase-plan.md.
 function excludeTriangles(triangles, bws, skinIndex, exclude) {
   let count = 0;
   if (bws != null && bws.length > 0) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -215,10 +215,10 @@ function htmlPagePlugin({ filename, extraChunks = [], chunksSortMode, inject }) 
 }
 
 const threeExamplesDir = path.resolve(__dirname, "node_modules", "three", "examples");
-const basisTranscoderPath = path.resolve(threeExamplesDir, "js", "libs", "basis", "basis_transcoder.js");
-const dracoWasmWrapperPath = path.resolve(threeExamplesDir, "js", "libs", "draco", "gltf", "draco_wasm_wrapper.js");
-const basisWasmPath = path.resolve(threeExamplesDir, "js", "libs", "basis", "basis_transcoder.wasm");
-const dracoWasmPath = path.resolve(threeExamplesDir, "js", "libs", "draco", "gltf", "draco_decoder.wasm");
+const basisTranscoderPath = path.resolve(threeExamplesDir, "jsm", "libs", "basis", "basis_transcoder.js");
+const dracoWasmWrapperPath = path.resolve(threeExamplesDir, "jsm", "libs", "draco", "gltf", "draco_wasm_wrapper.js");
+const basisWasmPath = path.resolve(threeExamplesDir, "jsm", "libs", "basis", "basis_transcoder.wasm");
+const dracoWasmPath = path.resolve(threeExamplesDir, "jsm", "libs", "draco", "gltf", "draco_decoder.wasm");
 
 module.exports = async (env, argv) => {
   env = env || {};


### PR DESCRIPTION
**Stacked on #3** (base = `claude/keen-hypatia-8gcrul`). Squashed to one clean commit.

Phase A of the renderer rebase (plan: `doc/renderer-rebase-plan.md`). Bumps the three **runtime** from the r141 fork to upstream **0.149.0** + a rebased patch stack, capturing ~8 releases of upstream fixes — notably GLTFLoader hardening relevant to the malformed-VRM avatar crash — and `matrixWorldAutoUpdate` (r147), **without touching the A-Frame fork**.

### Why r149 (not r150)
r150 is the "mass removal" release — it deletes the `*BufferGeometry` aliases, `BasisTextureLoader`, and the old `Object3D` static names, turning the bump into a ~30-file migration. **r149 keeps every one of those deprecated aliases at runtime**, so it's the last clean stepping stone. The r150 removal migration + the r152 color-management migration are deferred to Phase C.

### The `@types/three` pin (key to "no new tsc errors")
We bump the three **runtime** to 0.149 but keep **`@types/three@^0.141.0`** (unchanged from master). tsc only sees `@types/three`, so type-checking behaves exactly as today — no new errors, no `as any`. r149's runtime still ships all the deprecated aliases the 0.141 types describe (`PlaneBufferGeometry`, `Scene.autoUpdate`, `renderer.physicallyCorrectLights`, `BasisTextureLoader`), so the type/runtime skew is safe. Bumping `@types/three` to match is part of the Phase C migration.

### Changes
- `three` 0.141.0 → **0.149.0** (registry, integrity-locked); `@types/three` **stays ^0.141.0**.
- `patches/three+0.141.0.patch` → **`patches/three+0.149.0.patch`** (3-way merged; Object3D matrix-opt + reflection-probe hunks resolved behavior-preserving; WebXRManager hunk dropped — upstreamed in r149).
- `Object3D.DefaultUp`/`DefaultMatrixAutoUpdate` → `DEFAULT_*` (the one genuine r149 runtime removal we use; 3 untyped `.js` sites; A-Frame fork doesn't use them).
- webpack transcoder paths → `examples/jsm/libs` (moved in r149); `BasisTextureLoader` import stays stock.
- `.browserslistrc` Safari/iOS ≥ 17, Chrome ≥ 91; `.npmrc` + Dockerfile `--legacy-peer-deps` for the intentional three-ahead-of-A-Frame peer mismatch.
- `// UPGRADE` annotations at the renderer-feature seams + `doc/renderer-rebase-plan.md` (Phases A/B/C, the @types-pin rationale, and what r149 means for an A-Frame bump).

### Verification
`npm run check` (tsc — expected green, `@types/three` unchanged) + `npm run build` (Docker build runs this), plus a browser/VR/visionOS smoke test (reflection probes, range-request media, avatars).

### Follow-ups
- **Phase B**: retire the matrix-opt behind a dozens-of-avatars benchmark (decouples the A-Frame fork from the custom `Object3D`).
- **Phase C**: cross r150 (removal migration) + r152 (color management) and move A-Frame to upstream 1.4/1.5 — these are version-locked and done together.